### PR TITLE
Fix const correctness in meditate and trance

### DIFF
--- a/src/skills.c
+++ b/src/skills.c
@@ -3217,7 +3217,7 @@ void do_rescue( CHAR_DATA* ch, const char* argument )
 
 void do_meditate( CHAR_DATA * ch, const char *argument )
 {
-   char *arg = NULL;
+   const char *arg = NULL;
    int percent;
    int managain = ( IS_ELDARI(ch) ? 0 : 22 ); //was druid... potential change
 
@@ -3438,7 +3438,7 @@ void do_meditate( CHAR_DATA * ch, const char *argument )
 
 void do_trance( CHAR_DATA * ch, const char *argument )
 {
-   char *arg = NULL;
+   const char *arg = NULL;
    int percent;
    int managain = ( IS_ELDARI(ch) ? 0 : 50 ); // was druid... potential change
 


### PR DESCRIPTION
## Summary
- update the temporary argument pointer in meditate and trance to use const char* to match CHAR_DATA::alloc_ptr

## Testing
- `make` *(fails: /usr/bin/ld: unrecognized option '--export-all-symbols')*

------
https://chatgpt.com/codex/tasks/task_e_68cafabfbdec8327ac52a980d61728d5