### PR TITLE
Summarize combat damage and PL gains

### DIFF
--- a/src/mud.h
+++ b/src/mud.h
@@ -2412,6 +2412,7 @@ struct char_data
    time_t save_time;
    short timer;
    short wait;
+   bool suppress_exp_message;                                         /* Suppress PL gain messaging (combat summaries handle it) */
    int active_transformation;      /* Active transformation skill number */
    int transform_duration;         /* Remaining duration */
    int transform_upkeep_debt;      /* Mana debt */
@@ -2504,6 +2505,14 @@ struct killed_data
    char count;
 };
 
+typedef enum
+{
+   DMG_EFFECT_NORMAL = 0,
+   DMG_EFFECT_RESIST,
+   DMG_EFFECT_SUSCEPT,
+   DMG_EFFECT_IMMUNE
+} damage_effect_type;
+
 /* Structure for link list of ignored players */
 struct ignore_data
 {
@@ -2593,9 +2602,14 @@ struct pc_data
 	int absorption_debt;         					/* PL debt for bio-androids to collect on absorption */
 	short absorbed_count;        					/* Bio-android absorption tracking */
 	short evolution_stage;       					/* Bio-android evolution level */
-	short android_components[6];    /* Components: nano, quantum, plasma, neural, fusion, ethereal */
+        short android_components[6];    /* Components: nano, quantum, plasma, neural, fusion, ethereal */
    short android_schematics;       /* Bitmask: bits 0-5 for unlocked schematics */
    short android_installed;        /* Bitmask: bits 0-5 for installed transformations */
+   long long combat_damage;                                           /* Total damage dealt during the current combat */
+   long long combat_pl_gain;                                         /* Total PL gained from damage this combat */
+   bool combat_hit_resisted;                                         /* Whether any attack was resisted */
+   bool combat_hit_susceptible;                                      /* Whether any attack benefited from susceptibility */
+   bool combat_hit_immune;                                           /* Whether any attack was negated by immunity */
 };
 
 /*

--- a/src/update.c
+++ b/src/update.c
@@ -180,9 +180,15 @@ void gain_exp( CHAR_DATA * ch, int gain )
    ch->exp = ch->power_level.get_base();
    
    if( pl_gain > 0 )
-      ch_printf( ch, "&GYou gain &Y%s &Gpower level!\r\n", num_punct_ll( pl_gain ) );
+   {
+      if( !ch->suppress_exp_message )
+         ch_printf( ch, "&GYou gain &Y%s &Gpower level!\r\n", num_punct_ll( pl_gain ) );
+   }
    else if( pl_gain < 0 )
-      ch_printf( ch, "&RYou lose &Y%s &Rpower level!\r\n", num_punct_ll( -pl_gain ) );
+   {
+      if( !ch->suppress_exp_message )
+         ch_printf( ch, "&RYou lose &Y%s &Rpower level!\r\n", num_punct_ll( -pl_gain ) );
+   }
       
    save_char_obj( ch );
 	


### PR DESCRIPTION
## Summary
- add combat tracking helpers and per-character counters to report total damage and PL gained during each fight
- capture damage effectiveness and accumulate combat PL gains while suppressing redundant gain_exp messaging
- emit a color-coded end-of-combat summary and stop awarding duplicate post-combat experience from group_gain
- add a suppression flag for gain_exp notifications so other sources (such as absorption) can continue messaging normally
- declare the projectile-hit damage effect variable so the new reporting logic compiles cleanly

## Testing
- make *(fails: `make: *** No targets specified and no makefile found.  Stop.` in this environment)*
- make -f Makefile.devcc *(fails: `/bin/sh: 1: gcc.exe: not found` in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cb00a5024c8327a682e9e4b9fee6f5