### PR TITLE
Use do_morph_char for android spells

### DIFF
--- a/src/android.c
+++ b/src/android.c
@@ -446,8 +446,7 @@ ch_ret spell_aegis( int sn, int level, CHAR_DATA *ch, void *vo )
         send_to_char( "Aegis transformation not available.\r\n", ch );
         return rSPELL_FAILED;
     }
-    do_morph( ch, morph );
-    return rNONE;
+    return do_morph_char( ch, morph ) ? rNONE : rSPELL_FAILED;
 }
 
 /* Titan Protocol - Primordial Giant Transformation */
@@ -472,8 +471,7 @@ ch_ret spell_titan( int sn, int level, CHAR_DATA *ch, void *vo )
         send_to_char( "Titan transformation not available.\r\n", ch );
         return rSPELL_FAILED;
     }
-    do_morph( ch, morph );
-    return rNONE;
+    return do_morph_char( ch, morph ) ? rNONE : rSPELL_FAILED;
 }
 
 /* Valkyrie Protocol - Chosen Warrior Transformation */
@@ -498,8 +496,7 @@ ch_ret spell_valkyrie( int sn, int level, CHAR_DATA *ch, void *vo )
         send_to_char( "Valkyrie transformation not available.\r\n", ch );
         return rSPELL_FAILED;
     }
-    do_morph( ch, morph );
-    return rNONE;
+    return do_morph_char( ch, morph ) ? rNONE : rSPELL_FAILED;
 }
 
 /* Olympus Protocol - Divine Authority Transformation */
@@ -524,8 +521,7 @@ ch_ret spell_olympus( int sn, int level, CHAR_DATA *ch, void *vo )
         send_to_char( "Olympus transformation not available.\r\n", ch );
         return rSPELL_FAILED;
     }
-    do_morph( ch, morph );
-    return rNONE;
+    return do_morph_char( ch, morph ) ? rNONE : rSPELL_FAILED;
 }
 
 /* Ragnarok Protocol - Twilight of Gods Transformation */
@@ -550,8 +546,7 @@ ch_ret spell_ragnarok( int sn, int level, CHAR_DATA *ch, void *vo )
         send_to_char( "Ragnarok transformation not available.\r\n", ch );
         return rSPELL_FAILED;
     }
-    do_morph( ch, morph );
-    return rNONE;
+    return do_morph_char( ch, morph ) ? rNONE : rSPELL_FAILED;
 }
 
 /* Excalibur Protocol - Legendary Blade Transformation */
@@ -576,6 +571,5 @@ ch_ret spell_excalibur( int sn, int level, CHAR_DATA *ch, void *vo )
         send_to_char( "Excalibur transformation not available.\r\n", ch );
         return rSPELL_FAILED;
     }
-    do_morph( ch, morph );
-    return rNONE;
+    return do_morph_char( ch, morph ) ? rNONE : rSPELL_FAILED;
 }


### PR DESCRIPTION
## Summary
- route android protocol spells through do_morph_char so morph messaging is emitted

## Testing
- make *(fails: fight.c:1926:7: error: ‘effect’ was not declared in this scope)*

------
https://chatgpt.com/codex/tasks/task_e_68cb07cd95c48327b1f6502e88a31872