### PR TITLE
Ensure logon power level resets when entering game

### DIFF
--- a/src/comm.c
+++ b/src/comm.c
@@ -2525,6 +2525,7 @@ void nanny_read_motd( DESCRIPTOR_DATA * d, const char *argument )
 
    add_char( ch );
    d->connected = CON_PLAYING;
+   set_logon_powerlevel( ch );
 
    if( ch->level == 0 )
    {
@@ -2920,6 +2921,7 @@ short check_reconnect( DESCRIPTOR_DATA * d, const char *name, bool fConn )
             act( AT_ACTION, "$n has reconnected.", ch, NULL, NULL, TO_CANSEE );
             log_printf_plus( LOG_COMM, UMAX( sysdata.log_level, ch->level ), "%s (%s) reconnected.", ch->name, d->host );
             d->connected = CON_PLAYING;
+            set_logon_powerlevel( ch );
             do_look( ch, "auto" );
             check_loginmsg( ch );
          }

--- a/src/hotboot.c
+++ b/src/hotboot.c
@@ -821,6 +821,7 @@ void hotboot_recover( void )
          act( AT_MAGIC, "A puff of ethereal smoke dissipates around you!", d->character, NULL, NULL, TO_CHAR );
          act( AT_MAGIC, "$n appears in a puff of ethereal smoke!", d->character, NULL, NULL, TO_ROOM );
          d->connected = CON_PLAYING;
+         set_logon_powerlevel( d->character );
          if( ++num_descriptors > sysdata.maxplayers )
             sysdata.maxplayers = num_descriptors;
 #ifdef AUTO_AUTH


### PR DESCRIPTION
## Summary
- call `set_logon_powerlevel` as characters enter the game from the login flow or when reconnecting to ensure PL deltas reset for the new session
- apply the same logon snapshot when hotboot recovery returns players to play so the "PL GAINED SINCE LOGON" display stays accurate

## Testing
- make -f Makefile.devcc *(fails: gcc.exe not available in container)*
- make *(fails: Windows-specific linker flag `--export-all-symbols` unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68cb14918c688327bc19af9c9dc896c8