### PR TITLE
Expose clean target for all platforms

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -60,15 +60,15 @@ smaug: $(O_FILES)
 	chmod a+x smaug.exe
 	chmod g+w $(O_FILES)
 
-clean:
-	@rm -f o/*.o smaug.exe dependencies.d resolver.exe resolver.o *~
-
 else
 smaug: $(O_FILES)
 	rm -f smaug
 	$(CC) -o smaug $(O_FILES) $(L_FLAGS)
 	@echo "Done compiling mud."
 endif
+
+clean:
+	@rm -f o/*.o smaug smaug.exe dependencies.d resolver resolver.exe resolver.o *~
 
 dns: resolver.o
 	rm -f resolver


### PR DESCRIPTION
## Summary
- move the clean target out of the CYGWIN conditional so it is always available
- ensure the clean recipe removes smaug binaries and related build artifacts

## Testing
- make -C src clean

------
https://chatgpt.com/codex/tasks/task_e_68d87c9c76c4832785451c513c2a595f