### PR TITLE
Prevent duplicate melee damage messaging

### DIFF
--- a/src/fight.c
+++ b/src/fight.c
@@ -1872,7 +1872,7 @@ ch_ret one_hit( CHAR_DATA * ch, CHAR_DATA * victim, int dt )
    enhanced_dam_message_ex( ch, victim, dam, ( unsigned int ) dt, wield, pl_gain, band, avo );
 
    if( dam > 0 )
-      retcode = damage( ch, victim, dam, dt );
+      retcode = damage_ex( ch, victim, dam, dt, true );
    else
       retcode = rNONE;
 
@@ -2257,7 +2257,7 @@ short ris_damage( CHAR_DATA * ch, short dam, int ris )
 /*
  * Inflict damage from a hit. This is one damn big function.
  */
-ch_ret damage( CHAR_DATA * ch, CHAR_DATA * victim, int dam, int dt )
+ch_ret damage_ex( CHAR_DATA * ch, CHAR_DATA * victim, int dam, int dt, bool suppress_message )
 {
    char log_buf[MAX_STRING_LENGTH];
    short maxdam;
@@ -2486,8 +2486,8 @@ ch_ret damage( CHAR_DATA * ch, CHAR_DATA * victim, int dam, int dt )
    }
 
    /* Handle the damage message display */
-	if( ch != victim )
-		new_dam_message( ch, victim, dam, dt, NULL, pl_gained );
+   if( ch != victim && !suppress_message )
+      new_dam_message( ch, victim, dam, dt, NULL, pl_gained );
 
    /*
     * Hurt the victim.

--- a/src/mud.h
+++ b/src/mud.h
@@ -4906,7 +4906,8 @@ void violence_update( void );
 ch_ret multi_hit( CHAR_DATA * ch, CHAR_DATA * victim, int dt );
 ch_ret projectile_hit( CHAR_DATA * ch, CHAR_DATA * victim, OBJ_DATA * wield, OBJ_DATA * projectile, short dist );
 short ris_damage( CHAR_DATA * ch, short dam, int ris );
-ch_ret damage( CHAR_DATA * ch, CHAR_DATA * victim, int dam, int dt );
+ch_ret damage_ex( CHAR_DATA * ch, CHAR_DATA * victim, int dam, int dt, bool suppress_message );
+#define damage(ch, victim, dam, dt) damage_ex( (ch), (victim), (dam), (dt), false )
 void update_pos( CHAR_DATA * victim );
 void set_fighting( CHAR_DATA * ch, CHAR_DATA * victim );
 void stop_fighting( CHAR_DATA * ch, bool fBoth );


### PR DESCRIPTION
## Summary
- add a suppress-message flag to the core damage routine and expose it as `damage_ex`
- have `one_hit` use the new flag so enhanced melee text is only emitted once per swing
- keep existing callers working through a compatibility macro in `mud.h`

## Testing
- make -C src

------
https://chatgpt.com/codex/tasks/task_e_68d88b4a4adc8327ae312cb200d42ee7