### PR TITLE
Refactor skill storage to tenths with caps and persistence updates

### DIFF
--- a/src/act_comm.c
+++ b/src/act_comm.c
@@ -3346,7 +3346,7 @@ int knows_language( CHAR_DATA * ch, int language, CHAR_DATA * cch )
          if( IS_SET( language, lang_array[lang] ) && IS_SET( ch->speaks, lang_array[lang] ) )
          {
             if( ( sn = skill_lookup( lang_names[lang] ) ) != -1 )
-               return ch->pcdata->learned[sn];
+               return ch->pcdata->skills[sn].value_tenths / 10;
          }
    }
    return 0;
@@ -3376,7 +3376,7 @@ bool can_learn_lang( CHAR_DATA * ch, int language )
                bug( "%s: valid language without sn: %d", __func__, lang );
                continue;
             }
-            if( ch->pcdata->learned[sn] >= 99 )
+            if( ch->pcdata->skills[sn].value_tenths >= 990 )
                return FALSE;
          }
    }
@@ -3492,7 +3492,7 @@ void do_languages( CHAR_DATA* ch, const char* argument )
          return;
       }
       if( race_table[ch->race]->language & lang_array[lang] ||
-          lang_array[lang] == LANG_COMMON || ch->pcdata->learned[sn] >= 99 )
+          lang_array[lang] == LANG_COMMON || ch->pcdata->skills[sn].value_tenths >= 990 )
       {
          act( AT_PLAIN, "You are already fluent in $t.", ch, lang_names[lang], NULL, TO_CHAR );
          return;
@@ -3508,7 +3508,7 @@ void do_languages( CHAR_DATA* ch, const char* argument )
          send_to_char( "There is no one who can teach that language here.\r\n", ch );
          return;
       }
-      if( countlangs( ch->speaks ) >= ( ch->level / 10 ) && ch->pcdata->learned[sn] <= 0 )
+      if( countlangs( ch->speaks ) >= ( ch->level / 10 ) && ch->pcdata->skills[sn].value_tenths <= 0 )
       {
          act( AT_TELL, "$n tells you 'You may not learn a new language yet.'", sch, NULL, ch, TO_VICT );
          return;
@@ -3527,16 +3527,16 @@ void do_languages( CHAR_DATA* ch, const char* argument )
        * Max 12% (5 + 4 + 3) at 24+ int and 21+ wis. -- Altrag 
        */
       prct = 5 + ( get_curr_int( ch ) / 6 ) + ( get_curr_wis( ch ) / 7 );
-      ch->pcdata->learned[sn] += prct;
-      ch->pcdata->learned[sn] = UMIN( ch->pcdata->learned[sn], 99 );
+      ch->pcdata->skills[sn].value_tenths += prct * 10;
+      ch->pcdata->skills[sn].value_tenths = UMIN( ch->pcdata->skills[sn].value_tenths, 990 );
       SET_BIT( ch->speaks, lang_array[lang] );
-      if( ch->pcdata->learned[sn] == prct )
+      if( ch->pcdata->skills[sn].value_tenths == prct * 10 )
          act( AT_PLAIN, "You begin lessons in $t.", ch, lang_names[lang], NULL, TO_CHAR );
-      else if( ch->pcdata->learned[sn] < 60 )
+      else if( ch->pcdata->skills[sn].value_tenths < 600 )
          act( AT_PLAIN, "You continue lessons in $t.", ch, lang_names[lang], NULL, TO_CHAR );
-      else if( ch->pcdata->learned[sn] < 60 + prct )
+      else if( ch->pcdata->skills[sn].value_tenths < 600 + ( prct * 10 ) )
          act( AT_PLAIN, "You feel you can start communicating in $t.", ch, lang_names[lang], NULL, TO_CHAR );
-      else if( ch->pcdata->learned[sn] < 99 )
+      else if( ch->pcdata->skills[sn].value_tenths < 990 )
          act( AT_PLAIN, "You become more fluent in $t.", ch, lang_names[lang], NULL, TO_CHAR );
       else
          act( AT_PLAIN, "You now speak perfect $t.", ch, lang_names[lang], NULL, TO_CHAR );

--- a/src/act_move.c
+++ b/src/act_move.c
@@ -889,7 +889,7 @@ ch_ret move_char( CHAR_DATA * ch, EXIT_DATA * pexit, int fall )
 
          if( !found && !ch->mount )
          {
-            if( ( !IS_NPC( ch ) && number_percent(  ) > LEARNED( ch, gsn_climb ) ) || drunk || ch->mental_state < -90 )
+            if( ( !IS_NPC( ch ) && number_percent(  ) > learned_percent( ch, gsn_climb ) ) || drunk || ch->mental_state < -90 )
             {
                send_to_char( "You start to climb... but lose your grip and fall!\r\n", ch );
                learn_from_failure( ch, gsn_climb );
@@ -2041,7 +2041,7 @@ void do_bashdoor( CHAR_DATA* ch, const char* argument)
       else
          keyword = pexit->keyword;
       if( !IS_NPC( ch ) )
-         schance = LEARNED( ch, gsn_bashdoor ) / 2;
+         schance = learned_percent( ch, gsn_bashdoor ) / 2;
       else
          schance = 90;
       if( IS_SET( pexit->exit_info, EX_LOCKED ) )

--- a/src/act_obj.c
+++ b/src/act_obj.c
@@ -1458,7 +1458,7 @@ bool remove_obj( CHAR_DATA * ch, int iWear, bool fReplace )
  */
 bool could_dual( CHAR_DATA * ch )
 {
-   if( IS_NPC( ch ) || ch->pcdata->learned[gsn_dual_wield] )
+   if( IS_NPC( ch ) || ch->pcdata->skills[gsn_dual_wield].value_tenths )
       return TRUE;
 
    return FALSE;

--- a/src/act_wiz.c
+++ b/src/act_wiz.c
@@ -3692,7 +3692,7 @@ void do_balzhur( CHAR_DATA* ch, const char* argument )
    victim->max_mana = 100;
    victim->max_move = 100;
    for( sn = 0; sn < num_skills; ++sn )
-      victim->pcdata->learned[sn] = 0;
+      victim->pcdata->skills[sn].value_tenths = 0;
    victim->practice = 0;
    victim->hit = victim->max_hit;
    victim->mana = victim->max_mana;
@@ -3861,7 +3861,7 @@ void do_advance( CHAR_DATA* ch, const char* argument )
       victim->max_mana = 100;
       victim->max_move = 100;
       for( sn = 0; sn < num_skills; ++sn )
-         victim->pcdata->learned[sn] = 0;
+         victim->pcdata->skills[sn].value_tenths = 0;
       victim->practice = 0;
       victim->hit = victim->max_hit;
       victim->mana = victim->max_mana;
@@ -4093,7 +4093,7 @@ void do_immortalize( CHAR_DATA* ch, const char* argument )
 
          for( sn = 0; sn < num_skills; ++sn )
             if( skill_table[sn]->guild == victim->pcdata->clan->Class && skill_table[sn]->name != NULL )
-               victim->pcdata->learned[sn] = 0;
+               victim->pcdata->skills[sn].value_tenths = 0;
       }
       if( victim->speaking & LANG_CLAN )
          victim->speaking = LANG_COMMON;
@@ -5657,7 +5657,7 @@ void do_mortalize( CHAR_DATA * ch, const char *argument )
       victim->max_mana = 800;
       victim->max_move = 800;
       for( sn = 0; sn < num_skills; sn++ )
-         victim->pcdata->learned[sn] = 0;
+         victim->pcdata->skills[sn].value_tenths = 0;
       victim->practice = 0;
       victim->hit = victim->max_hit;
       victim->mana = victim->max_mana;

--- a/src/build.c
+++ b/src/build.c
@@ -2996,7 +2996,7 @@ void do_mset( CHAR_DATA* ch, const char* argument )
 
             for( sn = 0; sn < num_skills; ++sn )
                if( skill_table[sn]->guild == victim->pcdata->clan->Class && skill_table[sn]->name != NULL )
-                  victim->pcdata->learned[sn] = 0;
+                  victim->pcdata->skills[sn].value_tenths = 0;
          }
          if( victim->speaking & LANG_CLAN )
             victim->speaking = LANG_COMMON;

--- a/src/clans.c
+++ b/src/clans.c
@@ -1439,7 +1439,7 @@ void do_induct( CHAR_DATA* ch, const char* argument )
       {
          if( skill_table[sn]->guild == clan->Class && skill_table[sn]->name != NULL )
          {
-            victim->pcdata->learned[sn] = GET_ADEPT( victim, sn );
+            victim->pcdata->skills[sn].value_tenths = GET_ADEPT( victim, sn );
             ch_printf( victim, "%s instructs you in the ways of %s.\r\n", ch->name, skill_table[sn]->name );
          }
       }
@@ -1635,7 +1635,7 @@ void do_outcast( CHAR_DATA* ch, const char* argument )
       for( sn = 0; sn < num_skills; ++sn )
          if( skill_table[sn]->guild == victim->pcdata->clan->Class && skill_table[sn]->name != NULL )
          {
-            victim->pcdata->learned[sn] = 0;
+            victim->pcdata->skills[sn].value_tenths = 0;
             ch_printf( victim, "You forget the ways of %s.\r\n", skill_table[sn]->name );
          }
    }

--- a/src/comm.c
+++ b/src/comm.c
@@ -2603,7 +2603,7 @@ void nanny_read_motd( DESCRIPTOR_DATA * d, const char *argument )
       if( ( iLang = skill_lookup( "common" ) ) < 0 )
          bug( "%s: cannot find common language.", __func__ );
       else
-         ch->pcdata->learned[iLang] = 100;
+         ch->pcdata->skills[iLang].value_tenths = 1000;
 
       /*
        * Give them their racial languages 
@@ -2617,7 +2617,7 @@ void nanny_read_motd( DESCRIPTOR_DATA * d, const char *argument )
                if( ( uLang = skill_lookup( lang_names[iLang] ) ) < 0 )
                   bug( "%s: cannot find racial language [%s].", __func__, lang_names[iLang] );
                else
-                  ch->pcdata->learned[uLang] = 100;
+                  ch->pcdata->skills[uLang].value_tenths = 1000;
             }
          }
       }

--- a/src/fight.c
+++ b/src/fight.c
@@ -293,9 +293,9 @@ void generate_focus( CHAR_DATA *ch )
     base_focus = number_range( 1, UMAX(1, get_curr_int(ch)) / 5 );
     
     // Apply defensive skill penalties (like DBSC)
-    if( ch->pcdata->learned[gsn_dodge] > 0 )
+    if( ch->pcdata->skills[gsn_dodge].value_tenths > 0 )
         penalty += 5;
-    if( ch->pcdata->learned[gsn_parry] > 0 )  // Using parry instead of block
+    if( ch->pcdata->skills[gsn_parry].value_tenths > 0 )  // Using parry instead of block
         penalty += 5;
     // Add other defensive skills as needed
     
@@ -1187,15 +1187,15 @@ ch_ret multi_hit( CHAR_DATA * ch, CHAR_DATA * victim, int dt )
     * 40% or higher is always hit.. don't learn anything here though. 
     * -- Altrag 
     */
-   schance = IS_NPC( ch ) ? 100 : ( LEARNED( ch, gsn_berserk ) * 5 / 2 );
+   schance = IS_NPC( ch ) ? 100 : ( learned_percent( ch, gsn_berserk ) * 5 / 2 );
    if( IS_AFFECTED( ch, AFF_BERSERK ) && number_percent(  ) < schance )
       if( ( retcode = one_hit( ch, victim, dt ) ) != rNONE || who_fighting( ch ) != victim )
          return retcode;
 
    if( get_eq_char( ch, WEAR_DUAL_WIELD ) )
    {
-      dual_bonus = IS_NPC( ch ) ? ( ch->level / 10 ) : ( LEARNED( ch, gsn_dual_wield ) / 10 );
-      schance = IS_NPC( ch ) ? ch->level : LEARNED( ch, gsn_dual_wield );
+      dual_bonus = IS_NPC( ch ) ? ( ch->level / 10 ) : ( learned_percent( ch, gsn_dual_wield ) / 10 );
+      schance = IS_NPC( ch ) ? ch->level : learned_percent( ch, gsn_dual_wield );
       if( number_percent(  ) < schance )
       {
          learn_from_success( ch, gsn_dual_wield );
@@ -1230,7 +1230,7 @@ ch_ret multi_hit( CHAR_DATA * ch, CHAR_DATA * victim, int dt )
       return retcode;
    }
 
-   schance = IS_NPC( ch ) ? ch->level : ( int )( ( LEARNED( ch, gsn_second_attack ) + dual_bonus ) / 1.5 );
+   schance = IS_NPC( ch ) ? ch->level : ( int )( ( learned_percent( ch, gsn_second_attack ) + dual_bonus ) / 1.5 );
    if( number_percent(  ) < schance )
    {
       learn_from_success( ch, gsn_second_attack );
@@ -1241,7 +1241,7 @@ ch_ret multi_hit( CHAR_DATA * ch, CHAR_DATA * victim, int dt )
    else
       learn_from_failure( ch, gsn_second_attack );
 
-   schance = IS_NPC( ch ) ? ch->level : ( int )( ( LEARNED( ch, gsn_third_attack ) + ( dual_bonus * 1.5 ) ) / 2 );
+   schance = IS_NPC( ch ) ? ch->level : ( int )( ( learned_percent( ch, gsn_third_attack ) + ( dual_bonus * 1.5 ) ) / 2 );
    if( number_percent(  ) < schance )
    {
       learn_from_success( ch, gsn_third_attack );
@@ -1252,7 +1252,7 @@ ch_ret multi_hit( CHAR_DATA * ch, CHAR_DATA * victim, int dt )
    else
       learn_from_failure( ch, gsn_third_attack );
 
-   schance = IS_NPC( ch ) ? ch->level : ( int )( ( LEARNED( ch, gsn_fourth_attack ) + ( dual_bonus * 2 ) ) / 3 );
+   schance = IS_NPC( ch ) ? ch->level : ( int )( ( learned_percent( ch, gsn_fourth_attack ) + ( dual_bonus * 2 ) ) / 3 );
    if( number_percent(  ) < schance )
    {
       learn_from_success( ch, gsn_fourth_attack );
@@ -1263,7 +1263,7 @@ ch_ret multi_hit( CHAR_DATA * ch, CHAR_DATA * victim, int dt )
    else
       learn_from_failure( ch, gsn_fourth_attack );
 
-   schance = IS_NPC( ch ) ? ch->level : ( int )( ( LEARNED( ch, gsn_fifth_attack ) + ( dual_bonus * 3 ) ) / 4 );
+   schance = IS_NPC( ch ) ? ch->level : ( int )( ( learned_percent( ch, gsn_fifth_attack ) + ( dual_bonus * 3 ) ) / 4 );
    if( number_percent(  ) < schance )
    {
       learn_from_success( ch, gsn_fifth_attack );
@@ -1348,7 +1348,7 @@ int weapon_prof_bonus_check( CHAR_DATA * ch, OBJ_DATA * wield, int *gsn_ptr )
 
       }
       if( *gsn_ptr != -1 )
-         bonus = ( int )( ( LEARNED( ch, *gsn_ptr ) - 50 ) / 10 );
+         bonus = ( int )( ( learned_percent( ch, *gsn_ptr ) - 50 ) / 10 );
 
       /*
        * Reduce weapon bonuses for misaligned clannies.
@@ -1668,9 +1668,9 @@ ch_ret one_hit( CHAR_DATA * ch, CHAR_DATA * victim, int dt )
    else if( ch->position == POS_EVASIVE )
       base_dam = ( int )( .8 * base_dam );
 
-   if( !IS_NPC( ch ) && ch->pcdata->learned[gsn_enhanced_damage] > 0 )
+   if( !IS_NPC( ch ) && ch->pcdata->skills[gsn_enhanced_damage].value_tenths > 0 )
    {
-      base_dam += ( int )( base_dam * LEARNED( ch, gsn_enhanced_damage ) / 120 );
+      base_dam += ( int )( base_dam * learned_percent( ch, gsn_enhanced_damage ) / 120 );
       learn_from_success( ch, gsn_enhanced_damage );
    }
 
@@ -2030,9 +2030,9 @@ ch_ret projectile_hit( CHAR_DATA * ch, CHAR_DATA * victim, OBJ_DATA * wield, OBJ
    else if( victim->position == POS_EVASIVE )
       dam = ( int )( .8 * dam );
 
-   if( !IS_NPC( ch ) && ch->pcdata->learned[gsn_enhanced_damage] > 0 )
+   if( !IS_NPC( ch ) && ch->pcdata->skills[gsn_enhanced_damage].value_tenths > 0 )
    {
-      dam += ( int )( dam * LEARNED( ch, gsn_enhanced_damage ) / 120 );
+      dam += ( int )( dam * learned_percent( ch, gsn_enhanced_damage ) / 120 );
       learn_from_success( ch, gsn_enhanced_damage );
    }
 
@@ -3676,10 +3676,10 @@ OBJ_DATA *raw_kill( CHAR_DATA * ch, CHAR_DATA * victim )
 			{
 					/* Try to steal a random skill */
 					int skill_num = number_range(0, MAX_SKILL-1);
-					if( victim->pcdata->learned[skill_num] > 0 && ch->pcdata->learned[skill_num] == 0 )
+					if( victim->pcdata->skills[skill_num].value_tenths > 0 && ch->pcdata->skills[skill_num].value_tenths == 0 )
 {
 						/* Bio-android learns the skill */
-						ch->pcdata->learned[skill_num] = victim->pcdata->learned[skill_num];
+						ch->pcdata->skills[skill_num].value_tenths = victim->pcdata->skills[skill_num].value_tenths;
 						ch_printf( ch, "&GYou absorb knowledge of %s from %s!&x\r\n", 
 									skill_table[skill_num]->name, victim->name );
 						act( AT_MAGIC, "$n's eyes flash as $e absorbs $N's knowledge!", ch, NULL, victim, TO_ROOM );

--- a/src/fishing.c
+++ b/src/fishing.c
@@ -231,7 +231,7 @@ public:
         auto& db = FishDatabase::getInstance();
         const auto& all_fish = db.getAllFish();
         
-        int fishing_skill = LEARNED(ch, skill_lookup("fishing"));
+        int fishing_skill = learned_percent(ch, skill_lookup("fishing"));
         
         // Build list of possible catches
         std::vector<const FishData*> possible_catches;

--- a/src/handler.c
+++ b/src/handler.c
@@ -1258,10 +1258,11 @@ void modify_skill( CHAR_DATA * ch, int sn, int mod, bool fAdd )
 {
    if( !IS_NPC( ch ) )
    {
+      int delta = mod * 10;
       if( fAdd )
-         ch->pcdata->learned[sn] += mod;
+         ch->pcdata->skills[sn].value_tenths += delta;
       else
-         ch->pcdata->learned[sn] = URANGE( 0, ch->pcdata->learned[sn] + mod, GET_ADEPT( ch, sn ) );
+         ch->pcdata->skills[sn].value_tenths = URANGE( 0, ch->pcdata->skills[sn].value_tenths + delta, GET_ADEPT( ch, sn ) );
    }
 }
 

--- a/src/magic.c
+++ b/src/magic.c
@@ -127,7 +127,7 @@ int ch_slookup( CHAR_DATA * ch, const char *name )
    // and, (b) ch's level is high enough
    if( IS_NPC(ch) )
       return sn;
-   if( ch->pcdata->learned[sn] > 0
+   if( ch->pcdata->skills[sn].value_tenths > 0
     && get_power_level(ch) >= skill_table[sn]->min_power_level )
    {
       return sn;
@@ -151,7 +151,7 @@ int ch_slookup( CHAR_DATA * ch, const char *name )
    {
       if( !skill_table[sn]->name )
          break;
-      if( ch->pcdata->learned[sn] > 0
+      if( ch->pcdata->skills[sn].value_tenths > 0
           && ch->level >= skill_table[sn]->skill_adept[ch->Class]
           && LOWER( name[0] ) == LOWER( skill_table[sn]->name[0] ) && !str_prefix( name, skill_table[sn]->name ) )
          return sn;
@@ -1774,7 +1774,7 @@ void do_cast( CHAR_DATA* ch, const char* argument )
       return;
    }
 
-   if( !IS_NPC( ch ) && ( number_percent(  ) + skill->difficulty * 5 ) > ch->pcdata->learned[sn] )
+   if( !IS_NPC( ch ) && ( number_percent(  ) + skill->difficulty * 5 ) > ( ch->pcdata->skills[sn].value_tenths / 10 ) )
    {
       /*
        * Some more interesting loss of concentration messages  -Thoric 

--- a/src/mud.h
+++ b/src/mud.h
@@ -2527,6 +2527,14 @@ struct ignore_data
 /*
  * Data which only PC's have.
  */
+typedef struct skill_state
+{
+   short value_tenths;   /* Stored skill value in tenths of a percent */
+   short cap_tenths;     /* Maximum attainable value in tenths */
+   signed char lock_state; /* Placeholder for lock status (unused yet) */
+   time_t last_used;     /* Timestamp of last use */
+} SKILL_STATE;
+
 struct pc_data
 {
    CHAR_DATA *pet;
@@ -2568,7 +2576,7 @@ struct pc_data
    short wizinvis;   								/* wizinvis level */
    short min_snoop;  								/* minimum snoop level */
    short condition[MAX_CONDS];
-   short learned[MAX_SKILL];
+   SKILL_STATE skills[MAX_SKILL];
    unsigned int cyber; 								/* bitmask of installed cybernetics (CYBER_*) */
    short quest_number;  							/* current *QUEST BEING DONE* DON'T REMOVE! */
    short quest_curr; 								/* current number of quest points */
@@ -5420,8 +5428,12 @@ char *rprog_type_to_name( int type );
 void oprog_act_trigger( const char *buf, OBJ_DATA * mobj, CHAR_DATA * ch, OBJ_DATA * obj, CHAR_DATA * victim, OBJ_DATA * target );
 void rprog_act_trigger( const char *buf, ROOM_INDEX_DATA * room, CHAR_DATA * ch, OBJ_DATA * obj, CHAR_DATA * victim, OBJ_DATA * target );
 
-#define GET_ADEPT(ch,sn)    ( IS_IMMORTAL(ch) ? 100 : skill_table[(sn)]->skill_adept[(ch)->Class] )
-#define LEARNED(ch,sn)	    (IS_NPC(ch) ? 80 : URANGE(0, (ch)->pcdata->learned[(sn)], 101))
+#define GET_ADEPT(ch,sn)    ( IS_IMMORTAL(ch) ? 1000 : ( skill_table[(sn)]->skill_adept[(ch)->Class] * 10 ) )
+#define LEARNED(ch,sn)	    (IS_NPC(ch) ? 800 : ( (ch)->pcdata ? (ch)->pcdata->skills[(sn)].value_tenths : 0 ))
+static inline int learned_percent( CHAR_DATA *ch, int sn )
+{
+   return LEARNED( ch, sn ) / 10;
+}
 
 /* List handling v2.0, expanded a bit - Luc 06/2007
    Whoa! Eight years since I wrote v1.0...  :( */

--- a/src/mud_comm.c
+++ b/src/mud_comm.c
@@ -1978,6 +1978,8 @@ void do_mp_practice( CHAR_DATA* ch, const char* argument )
       return;
    }
 
+   max *= 10;
+
    if( get_power_level(victim) < skill_table[sn]->min_power_level )
    {
       snprintf( buf, MAX_INPUT_LENGTH, "$n attempts to tutor you in %s, but it's beyond your comprehension.", fskill_name );
@@ -1990,7 +1992,7 @@ void do_mp_practice( CHAR_DATA* ch, const char* argument )
     */
    adept = GET_ADEPT( victim, sn );
 
-   if( ( victim->pcdata->learned[sn] >= adept ) || ( victim->pcdata->learned[sn] >= max ) )
+   if( ( victim->pcdata->skills[sn].value_tenths >= adept ) || ( victim->pcdata->skills[sn].value_tenths >= max ) )
    {
       snprintf( buf, MAX_INPUT_LENGTH, "$n shows some knowledge of %s, but yours is clearly superior.", fskill_name );
       act( AT_TELL, buf, ch, NULL, victim, TO_VICT );
@@ -2003,11 +2005,11 @@ void do_mp_practice( CHAR_DATA* ch, const char* argument )
    act( AT_ACTION, "$N demonstrates $t to you.  You feel more learned in this subject.", victim, skill_table[sn]->name, ch,
         TO_CHAR );
 
-   victim->pcdata->learned[sn] = max;
+   victim->pcdata->skills[sn].value_tenths = max;
 
-   if( victim->pcdata->learned[sn] >= adept )
+   if( victim->pcdata->skills[sn].value_tenths >= adept )
    {
-      victim->pcdata->learned[sn] = adept;
+      victim->pcdata->skills[sn].value_tenths = adept;
       act( AT_TELL, "$n tells you, 'You have learned all I know on this subject...'", ch, NULL, victim, TO_VICT );
    }
 }

--- a/src/racial_transformations.c
+++ b/src/racial_transformations.c
@@ -351,7 +351,7 @@ void try_unlock_racial_transformation(CHAR_DATA *victim, CHAR_DATA *aggressor)
       return;  /* Already morphed */
       
    /* Check if already learned */
-   if (rt->skill_sn >= 0 && victim->pcdata->learned[rt->skill_sn] > 0)
+   if (rt->skill_sn >= 0 && victim->pcdata->skills[rt->skill_sn].value_tenths > 0)
       return;  /* Already learned */
 
    /* HP threshold check */
@@ -418,9 +418,9 @@ void try_unlock_racial_transformation(CHAR_DATA *victim, CHAR_DATA *aggressor)
       do_morph_char(victim, md);
 
       /* Permanently learn the transformation skill at 25% */
-      victim->pcdata->learned[rt->skill_sn] = UMAX(victim->pcdata->learned[rt->skill_sn], 25);
+      victim->pcdata->skills[rt->skill_sn].value_tenths = UMAX(victim->pcdata->skills[rt->skill_sn].value_tenths, 250);
       
-      ch_printf(victim, "&CYou have learned: &W%s &Cat 25%% proficiency!&D\r\n", 
+      ch_printf(victim, "&CYou have learned: &W%s &Cat 25.0%% proficiency!&D\r\n",
                 skill_table[rt->skill_sn]->name);
       ch_printf(victim, "&GUse '&W%s&G' to activate this transformation in the future.&D\r\n", 
                 rt->skill_name);
@@ -499,7 +499,7 @@ void do_testtransform(CHAR_DATA *ch, const char *argument)
    
    if (rt->skill_sn >= 0)
    {
-      ch_printf(ch, "  Current Skill Level: %d%%\r\n", victim->pcdata->learned[rt->skill_sn]);
+      ch_printf(ch, "  Current Skill Level: %.1f%%\r\n", victim->pcdata->skills[rt->skill_sn].value_tenths / 10.0);
    }
    
    /* Calculate current chance */

--- a/src/save.c
+++ b/src/save.c
@@ -29,7 +29,7 @@
  * Increment with every major format change.
  * Upped to 5 for addition of new Age Setup. - Kayle 1/22/08
  */
-const int SAVEVERSION = 5;
+const int SAVEVERSION = 6;
 
 /*
  * Array to keep track of equipment temporarily. - Thoric
@@ -571,25 +571,34 @@ void fwrite_char( CHAR_DATA * ch, FILE * fp )
 
    for( sn = 1; sn < num_skills; ++sn )
    {
-      if( skill_table[sn]->name && ch->pcdata->learned[sn] > 0 )
-         switch ( skill_table[sn]->type )
-         {
-            default:
-               fprintf( fp, "Skill        %d '%s'\n", ch->pcdata->learned[sn], skill_table[sn]->name );
-               break;
-            case SKILL_RACIAL:
-               fprintf( fp, "Ability      %d '%s'\n", ch->pcdata->learned[sn], skill_table[sn]->name );
-               break;
-            case SKILL_SPELL:
-               fprintf( fp, "Spell        %d '%s'\n", ch->pcdata->learned[sn], skill_table[sn]->name );
-               break;
-            case SKILL_WEAPON:
-               fprintf( fp, "Weapon       %d '%s'\n", ch->pcdata->learned[sn], skill_table[sn]->name );
-               break;
-            case SKILL_TONGUE:
-               fprintf( fp, "Tongue       %d '%s'\n", ch->pcdata->learned[sn], skill_table[sn]->name );
-               break;
-         }
+      if( !skill_table[sn]->name )
+         continue;
+
+      int value = URANGE( 0, ch->pcdata->skills[sn].value_tenths, 1000 );
+      int cap = ch->pcdata->skills[sn].cap_tenths;
+      int lock = ch->pcdata->skills[sn].lock_state;
+
+      if( value <= 0 && cap == 1000 && lock == 0 )
+         continue;
+
+      switch ( skill_table[sn]->type )
+      {
+         default:
+            fprintf( fp, "Skill        %d %d %d '%s'\n", value, cap, lock, skill_table[sn]->name );
+            break;
+         case SKILL_RACIAL:
+            fprintf( fp, "Ability      %d %d %d '%s'\n", value, cap, lock, skill_table[sn]->name );
+            break;
+         case SKILL_SPELL:
+            fprintf( fp, "Spell        %d %d %d '%s'\n", value, cap, lock, skill_table[sn]->name );
+            break;
+         case SKILL_WEAPON:
+            fprintf( fp, "Weapon       %d %d %d '%s'\n", value, cap, lock, skill_table[sn]->name );
+            break;
+         case SKILL_TONGUE:
+            fprintf( fp, "Tongue       %d %d %d '%s'\n", value, cap, lock, skill_table[sn]->name );
+            break;
+      }
    }
 
    for( paf = ch->first_affect; paf; paf = paf->next )
@@ -855,7 +864,10 @@ bool load_char_obj( DESCRIPTOR_DATA * d, char *name, bool preload, bool copyover
    ch->mental_state = -10;
    ch->mobinvis = 0;
    for( i = 0; i < MAX_SKILL; i++ )
-      ch->pcdata->learned[i] = 0;
+      ch->pcdata->skills[i].value_tenths = 0;
+      ch->pcdata->skills[i].cap_tenths = 1000;
+      ch->pcdata->skills[i].lock_state = 0;
+      ch->pcdata->skills[i].last_used = 0;
 	for( i = 0; i < MAX_ANDROID_COMPONENTS; i++ )		/* Initialize android component system */
 		ch->pcdata->android_components[i] = 0;
 	ch->pcdata->android_schematics = 0;
@@ -1106,28 +1118,37 @@ void fread_char( CHAR_DATA * ch, FILE * fp, bool preload, bool copyover )
 
             if( !str_cmp( word, "Ability" ) )
             {
-               int sn, value;
-
                if( preload )
                   word = "End";
                else
                {
+                  int sn, value, cap = 1000, lock = 0;
                   value = fread_number( fp );
+                  if( file_ver >= 6 )
+                  {
+                     cap = fread_number( fp );
+                     lock = fread_number( fp );
+                  }
+                  const char *skill_name = fread_word( fp );
                   if( file_ver < 3 )
-                     sn = skill_lookup( fread_word( fp ) );
+                     sn = skill_lookup( skill_name );
                   else
-                     sn = find_ability( NULL, fread_word( fp ), FALSE );
+                     sn = find_ability( NULL, skill_name, FALSE );
 
                   if( sn < 0 )
                      bug( "%s: unknown skill.", __func__ );
                   else
                   {
-                     ch->pcdata->learned[sn] = value;
+                     if( file_ver < 6 )
+                        value *= 10;
+                     ch->pcdata->skills[sn].value_tenths = URANGE( 0, value, 1000 );
+                     ch->pcdata->skills[sn].cap_tenths = ( file_ver >= 6 ) ? URANGE( 0, cap, 1000 ) : 1000;
+                     ch->pcdata->skills[sn].lock_state = ( file_ver >= 6 ) ? lock : 0;
                      if( ch->level < LEVEL_IMMORTAL )
                      {
                         if( skill_table[sn]->race_adept[ch->race] > 0 )
                         {
-                           ch->pcdata->learned[sn] = 0;
+                           ch->pcdata->skills[sn].value_tenths = 0;
                            ++ch->practice;
                         }
                      }
@@ -1748,33 +1769,42 @@ void fread_char( CHAR_DATA * ch, FILE * fp, bool preload, bool copyover )
 
             if( !strcmp( word, "Skill" ) )
             {
-               int sn, value;
-
                if( preload )
                   word = "End";
                else
                {
+                  int sn, value, cap = 1000, lock = 0;
                   value = fread_number( fp );
+                  if( file_ver >= 6 )
+                  {
+                     cap = fread_number( fp );
+                     lock = fread_number( fp );
+                  }
+                  const char *skill_name = fread_word( fp );
                   if( file_ver < 3 )
-                     sn = skill_lookup( fread_word( fp ) );
+                     sn = skill_lookup( skill_name );
                   else
-                     sn = find_skill( NULL, fread_word( fp ), FALSE );
+                     sn = find_skill( NULL, skill_name, FALSE );
 
                   if( sn < 0 )
                      bug( "%s: unknown skill.", __func__ );
                   else
                   {
-                     ch->pcdata->learned[sn] = value;
+                     if( file_ver < 6 )
+                        value *= 10;
+                     ch->pcdata->skills[sn].value_tenths = URANGE( 0, value, 1000 );
+                     ch->pcdata->skills[sn].cap_tenths = ( file_ver >= 6 ) ? URANGE( 0, cap, 1000 ) : 1000;
+                     ch->pcdata->skills[sn].lock_state = ( file_ver >= 6 ) ? lock : 0;
                      /*
                       * Take care of people who have stuff they shouldn't     *
                       * * Assumes class and level were loaded before. -- Altrag *
-                      * * Assumes practices are loaded first too now. -- Altrag 
+                      * * Assumes practices are loaded first too now. -- Altrag
                       */
                      if( ch->level < LEVEL_IMMORTAL )
                      {
                         if( skill_table[sn]->skill_adept[ch->Class] >= LEVEL_IMMORTAL )
                         {
-                           ch->pcdata->learned[sn] = 0;
+                           ch->pcdata->skills[sn].value_tenths = 0;
                            ++ch->practice;
                         }
                      }
@@ -1786,24 +1816,33 @@ void fread_char( CHAR_DATA * ch, FILE * fp, bool preload, bool copyover )
 
             if( !strcmp( word, "Spell" ) )
             {
-               int sn, value;
-
                if( preload )
                   word = "End";
                else
                {
+                  int sn, value, cap = 1000, lock = 0;
                   value = fread_number( fp );
+                  if( file_ver >= 6 )
+                  {
+                     cap = fread_number( fp );
+                     lock = fread_number( fp );
+                  }
 
-                  sn = find_spell( NULL, fread_word( fp ), FALSE );
+                  const char *skill_name = fread_word( fp );
+                  sn = find_spell( NULL, skill_name, FALSE );
                   if( sn < 0 )
                      bug( "%s: unknown spell.", __func__ );
                   else
                   {
-                     ch->pcdata->learned[sn] = value;
+                     if( file_ver < 6 )
+                        value *= 10;
+                     ch->pcdata->skills[sn].value_tenths = URANGE( 0, value, 1000 );
+                     ch->pcdata->skills[sn].cap_tenths = ( file_ver >= 6 ) ? URANGE( 0, cap, 1000 ) : 1000;
+                     ch->pcdata->skills[sn].lock_state = ( file_ver >= 6 ) ? lock : 0;
                      if( ch->level < LEVEL_IMMORTAL )
                         if( skill_table[sn]->skill_adept[ch->Class] >= LEVEL_IMMORTAL )
                         {
-                           ch->pcdata->learned[sn] = 0;
+                           ch->pcdata->skills[sn].value_tenths = 0;
                            ++ch->practice;
                         }
                   }
@@ -1894,22 +1933,32 @@ void fread_char( CHAR_DATA * ch, FILE * fp, bool preload, bool copyover )
          case 'T':
             if( !strcmp( word, "Tongue" ) )
             {
-               int sn, value;
                if( preload )
                   word = "End";
                else
                {
+                  int sn, value, cap = 1000, lock = 0;
                   value = fread_number( fp );
-                  sn = find_tongue( NULL, fread_word( fp ), FALSE );
+                  if( file_ver >= 6 )
+                  {
+                     cap = fread_number( fp );
+                     lock = fread_number( fp );
+                  }
+                  const char *skill_name = fread_word( fp );
+                  sn = find_tongue( NULL, skill_name, FALSE );
                   if( sn < 0 )
                      bug( "%s: unknown tongue.", __func__ );
                   else
                   {
-                     ch->pcdata->learned[sn] = value;
+                     if( file_ver < 6 )
+                        value *= 10;
+                     ch->pcdata->skills[sn].value_tenths = URANGE( 0, value, 1000 );
+                     ch->pcdata->skills[sn].cap_tenths = ( file_ver >= 6 ) ? URANGE( 0, cap, 1000 ) : 1000;
+                     ch->pcdata->skills[sn].lock_state = ( file_ver >= 6 ) ? lock : 0;
                      if( ch->level < LEVEL_IMMORTAL )
                         if( skill_table[sn]->skill_adept[ch->Class] >= LEVEL_IMMORTAL )
                         {
-                           ch->pcdata->learned[sn] = 0;
+                           ch->pcdata->skills[sn].value_tenths = 0;
                            ch->practice++;
                         }
                   }
@@ -1958,24 +2007,33 @@ void fread_char( CHAR_DATA * ch, FILE * fp, bool preload, bool copyover )
             KEY( "Weight", ch->weight, fread_number( fp ) );
             if( !strcmp( word, "Weapon" ) )
             {
-               int sn, value;
-
                if( preload )
                   word = "End";
                else
                {
+                  int sn, value, cap = 1000, lock = 0;
                   value = fread_number( fp );
+                  if( file_ver >= 6 )
+                  {
+                     cap = fread_number( fp );
+                     lock = fread_number( fp );
+                  }
 
-                  sn = find_weapon( NULL, fread_word( fp ), FALSE );
+                  const char *skill_name = fread_word( fp );
+                  sn = find_weapon( NULL, skill_name, FALSE );
                   if( sn < 0 )
                      bug( "%s: unknown weapon.", __func__ );
                   else
                   {
-                     ch->pcdata->learned[sn] = value;
+                     if( file_ver < 6 )
+                        value *= 10;
+                     ch->pcdata->skills[sn].value_tenths = URANGE( 0, value, 1000 );
+                     ch->pcdata->skills[sn].cap_tenths = ( file_ver >= 6 ) ? URANGE( 0, cap, 1000 ) : 1000;
+                     ch->pcdata->skills[sn].lock_state = ( file_ver >= 6 ) ? lock : 0;
                      if( ch->level < LEVEL_IMMORTAL )
                         if( skill_table[sn]->skill_adept[ch->Class] >= LEVEL_IMMORTAL )
                         {
-                           ch->pcdata->learned[sn] = 0;
+                           ch->pcdata->skills[sn].value_tenths = 0;
                            ++ch->practice;
                         }
                   }

--- a/src/track.c
+++ b/src/track.c
@@ -191,7 +191,7 @@ void do_track( CHAR_DATA* ch, const char* argument )
    char arg[MAX_INPUT_LENGTH];
    int dir, maxdist;
 
-   if( !IS_NPC( ch ) && ch->pcdata->learned[gsn_track] <= 0 )
+   if( !IS_NPC( ch ) && ch->pcdata->skills[gsn_track].value_tenths <= 0 )
    {
       send_to_char( "You do not know of this skill yet.\r\n", ch );
       return;
@@ -215,7 +215,7 @@ void do_track( CHAR_DATA* ch, const char* argument )
    maxdist = 100 + ch->level * 30;
 
    if( !IS_NPC( ch ) )
-      maxdist = ( maxdist * LEARNED( ch, gsn_track ) ) / 100;
+      maxdist = ( maxdist * learned_percent( ch, gsn_track ) ) / 100;
 
    dir = find_first_step( ch->in_room, vict->in_room, maxdist );
 


### PR DESCRIPTION
## Summary
- add a SKILL_STATE struct and replace pcdata->learned[] with tenths-based skill records plus a learned_percent helper
- update skill math, admin tooling, and UI to operate on tenths with optional cap/lock controls and decimal displays
- persist value/cap/lock triplets when saving characters and default language skills to 100% in tenths

## Testing
- make *(fails: no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_68d8ae265ed08327ac41e0409c2894b6