### PR TITLE
Persist skill metadata and normalization helpers

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -3040,12 +3040,19 @@ void clear_char( CHAR_DATA * ch )
 		ch->pcdata->android_schematics = 0;
 		ch->pcdata->android_installed = 0;
 	}
-	 if( ch->pcdata )
+   if( ch->pcdata )
    {
       ch->pcdata->dual_flip = FALSE;
       ch->pcdata->last_weapon = NULL;
       ch->pcdata->cached_prof_bonus = 0;
       ch->pcdata->cached_prof_gsn = -1;
+      ch->pcdata->skill_total_tenths = 0;
+      ch->pcdata->skill_cap_tenths = DEFAULT_SKILL_CAP_TENTHS;
+      ch->pcdata->skill_gain_pool = 0;
+      ch->pcdata->skill_gain_last_attempt = 0;
+      ch->pcdata->skill_gain_last_decay = 0;
+      ch->pcdata->physical_skill_meter = 0;
+      ch->pcdata->mental_skill_meter = 0;
    }
 }
 

--- a/src/mud.h
+++ b/src/mud.h
@@ -2527,11 +2527,18 @@ struct ignore_data
 /*
  * Data which only PC's have.
  */
+#define SKILL_LOCK_DOWN     -1
+#define SKILL_LOCK_STEADY    0
+#define SKILL_LOCK_UP        1
+
+#define DEFAULT_SKILL_CAP_TENTHS 7000
+#define MAX_SKILL_CAP_TENTHS     (MAX_SKILL * 1000)
+
 typedef struct skill_state
 {
    short value_tenths;   /* Stored skill value in tenths of a percent */
    short cap_tenths;     /* Maximum attainable value in tenths */
-   signed char lock_state; /* Placeholder for lock status (unused yet) */
+   signed char lock_state; /* See SKILL_LOCK_* constants */
    time_t last_used;     /* Timestamp of last use */
 } SKILL_STATE;
 
@@ -2577,6 +2584,13 @@ struct pc_data
    short min_snoop;  								/* minimum snoop level */
    short condition[MAX_CONDS];
    SKILL_STATE skills[MAX_SKILL];
+   int skill_total_tenths;
+   int skill_cap_tenths;
+   int skill_gain_pool;
+   time_t skill_gain_last_attempt;
+   time_t skill_gain_last_decay;
+   int physical_skill_meter;
+   int mental_skill_meter;
    unsigned int cyber; 								/* bitmask of installed cybernetics (CYBER_*) */
    short quest_number;  							/* current *QUEST BEING DONE* DON'T REMOVE! */
    short quest_curr; 								/* current number of quest points */
@@ -4953,6 +4967,8 @@ avoid_t avoid_reason_from_stance( CHAR_DATA *victim, int atk_type );
 int    get_skill_tenths( CHAR_DATA *ch, int sn );
 double get_skill( CHAR_DATA *ch, int sn );
 void   add_skill_tenths( CHAR_DATA *ch, int sn, int delta );
+void   normalize_skill_locks( CHAR_DATA *ch );
+void   recalc_skill_totals( CHAR_DATA *ch );
 void   skill_gain( CHAR_DATA *ch, int sn, int DR, bool success, int context_flags );
 void   enhanced_dam_message_ex( CHAR_DATA *ch, CHAR_DATA *victim, int dam, unsigned int dt,
                                 OBJ_DATA *wield, long long pl_gained,


### PR DESCRIPTION
## Summary
- add skill lock constants and per-character skill tracking fields for totals, caps, pools, and meters
- persist the new skill metadata in player saves and normalize/recaculate values during save and load
- add reusable helpers so admin edits keep skill locks and totals within the configured limits

## Testing
- make *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_68d8bcdf76c08327a79ec81c5b0004e7