### PR TITLE
Overhaul skill training and locking commands

### DIFF
--- a/src/comm.c
+++ b/src/comm.c
@@ -3989,8 +3989,14 @@ void display_prompt( DESCRIPTOR_DATA * d )
                      strlcpy( pbuf, "S", MAX_STRING_LENGTH );
                   break;
 
-               case 't':  /* Practice points */
-                  pstat = ch->practice;
+               case 't':  /* Total skill percentage */
+                  if( !IS_NPC( ch ) && ch->pcdata )
+                  {
+                     recalc_skill_totals( ch );
+                     pstat = ch->pcdata->skill_total_tenths / 10;
+                  }
+                  else
+                     pstat = 0;
                   break;
 
                case 'T':

--- a/src/mud.h
+++ b/src/mud.h
@@ -4208,6 +4208,7 @@ DECLARE_DO_FUN( do_pounce );
 DECLARE_DO_FUN( do_powerup );
 DECLARE_DO_FUN( do_powerdown );
 DECLARE_DO_FUN( do_practice );
+DECLARE_DO_FUN( do_skill );
 DECLARE_DO_FUN( do_project );
 DECLARE_DO_FUN( do_prompt );
 DECLARE_DO_FUN( do_pset );
@@ -5092,6 +5093,7 @@ void ability_learn_from_success( CHAR_DATA * ch, int sn );  // Allow for separat
 void learn_from_failure( CHAR_DATA * ch, int sn );
 void skill_gain_success( CHAR_DATA *ch, int sn, int context_flags );
 void skill_gain_failure( CHAR_DATA *ch, int sn, int context_flags );
+bool trainer_raise_skill_to( CHAR_DATA *ch, int sn, int target_tenths );
 bool check_parry( CHAR_DATA * ch, CHAR_DATA * victim );
 bool check_dodge( CHAR_DATA * ch, CHAR_DATA * victim );
 bool check_tumble( CHAR_DATA * ch, CHAR_DATA * victim );

--- a/src/mud_comm.c
+++ b/src/mud_comm.c
@@ -2005,7 +2005,14 @@ void do_mp_practice( CHAR_DATA* ch, const char* argument )
    act( AT_ACTION, "$N demonstrates $t to you.  You feel more learned in this subject.", victim, skill_table[sn]->name, ch,
         TO_CHAR );
 
-   victim->pcdata->skills[sn].value_tenths = max;
+   if( victim->pcdata->skills[sn].lock_state == SKILL_LOCK_DOWN )
+   {
+      act( AT_TELL, "$n tries to teach you, but you've locked that skill down.", ch, NULL, victim, TO_VICT );
+      return;
+   }
+
+   if( max > victim->pcdata->skills[sn].value_tenths )
+      trainer_raise_skill_to( victim, sn, max );
 
    if( victim->pcdata->skills[sn].value_tenths >= adept )
    {

--- a/src/player.c
+++ b/src/player.c
@@ -340,7 +340,15 @@ void do_score( CHAR_DATA* ch, const char* argument )
          snprintf( buf, MAX_STRING_LENGTH, "%s", "standard" );
          break;
    }
-   pager_printf( ch, "&cPRACT: &G%d&c                     &cLife: &G%-5d \r\n&D", ch->practice, ch->hit );
+   if( !IS_NPC( ch ) )
+   {
+      recalc_skill_totals( ch );
+      int skill_cap = ch->pcdata->skill_cap_tenths <= 0 ? DEFAULT_SKILL_CAP_TENTHS : ch->pcdata->skill_cap_tenths;
+      pager_printf( ch, "&cSKILL: &G%5.1f/%-5.1f&c             &cLife: &G%-5d \r\n&D",
+                    ch->pcdata->skill_total_tenths / 10.0, skill_cap / 10.0, ch->hit );
+   }
+   else
+      pager_printf( ch, "&cSKILL: &G----&c             &cLife: &G%-5d \r\n&D", ch->hit );
 
    pager_printf( ch, "&OGOLD : %-13s&c         &cMana: &C%d/%d&C&D \r\n", 
 				 num_punct( ch->gold ), ch->mana, ch->max_mana  );

--- a/src/racial_transformations.c
+++ b/src/racial_transformations.c
@@ -418,10 +418,12 @@ void try_unlock_racial_transformation(CHAR_DATA *victim, CHAR_DATA *aggressor)
       do_morph_char(victim, md);
 
       /* Permanently learn the transformation skill at 25% */
-      victim->pcdata->skills[rt->skill_sn].value_tenths = UMAX(victim->pcdata->skills[rt->skill_sn].value_tenths, 250);
+      int current_value = victim->pcdata->skills[rt->skill_sn].value_tenths;
+      if( current_value < 250 )
+         trainer_raise_skill_to( victim, rt->skill_sn, 250 );
       
-      ch_printf(victim, "&CYou have learned: &W%s &Cat 25.0%% proficiency!&D\r\n",
-                skill_table[rt->skill_sn]->name);
+      ch_printf(victim, "&CYou have learned: &W%s &Cat %.1f%% proficiency!&D\r\n",
+                skill_table[rt->skill_sn]->name, victim->pcdata->skills[rt->skill_sn].value_tenths / 10.0);
       ch_printf(victim, "&GUse '&W%s&G' to activate this transformation in the future.&D\r\n", 
                 rt->skill_name);
 

--- a/src/skill_training.c
+++ b/src/skill_training.c
@@ -168,37 +168,65 @@ void update_skill_meters(CHAR_DATA *ch, int skill_num, int old_level, int new_le
     }
 }
 
+
 void do_skillmeter(CHAR_DATA *ch, const char *argument) {
-    CHAR_DATA *victim;
-    
-    /* IMMORTALS ONLY - Hidden meters are not shown to players */
-    if(get_trust(ch) < LEVEL_IMMORTAL) {
-        send_to_char("Huh?\r\n", ch);
+    CHAR_DATA *victim = NULL;
+
+    if (IS_NPC(ch))
         return;
-    }
-    
-    /* Allow immortals to check players' meters */
-    if(argument[0] != '\0') {
-        if((victim = get_char_world(ch, argument)) == NULL) {
+
+    if (argument[0] != '\0') {
+        if (get_trust(ch) < LEVEL_IMMORTAL) {
+            send_to_char("This command does not take arguments.\r\n", ch);
+            return;
+        }
+
+        victim = get_char_world(ch, argument);
+        if (!victim) {
             send_to_char("They aren't here.\r\n", ch);
             return;
         }
-        if(IS_NPC(victim)) {
+        if (IS_NPC(victim)) {
             send_to_char("NPCs don't have skill meters.\r\n", ch);
             return;
         }
     } else {
-        send_to_char("Check whose skill meters? (skillmeter <player>)\r\n", ch);
+        victim = ch;
+    }
+
+    if (!victim->pcdata) {
+        send_to_char("No skill data available.\r\n", ch);
         return;
     }
-    
-    ch_printf(ch, "&W--- %s's Hidden Skill Meters (IMM ONLY) ---&x\r\n", victim->name);
-    ch_printf(ch, "&CPhysical Meter: &Y%d&C/100 (&Y%d%%&C) &W[Next HP gain]&x\r\n", 
-              victim->pcdata->physical_skill_meter, victim->pcdata->physical_skill_meter);
-    ch_printf(ch, "&BMental Meter:   &Y%d&C/100 (&Y%d%%&C) &W[Next mana gain]&x\r\n", 
-              victim->pcdata->mental_skill_meter, victim->pcdata->mental_skill_meter);
-    
-    if(victim->pcdata->physical_skill_meter == 0 && victim->pcdata->mental_skill_meter == 0) {
-        send_to_char("&YNo training progress yet.&x\r\n", ch);
-    }
+
+    recalc_skill_totals(victim);
+
+    int total = victim->pcdata->skill_total_tenths;
+    int cap = victim->pcdata->skill_cap_tenths <= 0 ? DEFAULT_SKILL_CAP_TENTHS : victim->pcdata->skill_cap_tenths;
+    int free_cap = UMAX(0, cap - total);
+    int percent = cap > 0 ? (total * 100) / cap : 0;
+    int pending = total - victim->pcdata->skill_gain_pool;
+    if (pending < 0)
+        pending = 0;
+
+    int physical = victim->pcdata->physical_skill_meter;
+    int mental = victim->pcdata->mental_skill_meter;
+
+    if (victim != ch)
+        ch_printf(ch, "&W--- %s's Skill Usage Overview ---&D\r\n", victim->name);
+    else
+        send_to_char("&W--- Skill Usage Overview ---&D\r\n", ch);
+
+    ch_printf(ch, "&WTotal Skill Points:&D %6.1f / %6.1f (%d%% of cap)\r\n",
+              total / 10.0, cap / 10.0, percent);
+    ch_printf(ch, "&WFree Capacity:&D    %6.1f\r\n", free_cap / 10.0);
+    ch_printf(ch, "&WPending Gains:&D   %6.1f (waiting for room in your cap)\r\n", pending / 10.0);
+    ch_printf(ch, "&WSkill Gain Pool:&D %6.1f\r\n", victim->pcdata->skill_gain_pool / 10.0);
+
+    ch_printf(ch, "&WPhysical Meter:&D   %3d%% &g(%d%% to next HP bonus)&D\r\n", physical, UMAX(0, 100 - physical));
+    ch_printf(ch, "&WMental Meter:&D     %3d%% &g(%d%% to next mana bonus)&D\r\n", mental, UMAX(0, 100 - mental));
+
+    if (victim == ch)
+        send_to_char("&WHint:&D Use '&WSKILL&D' to review locks and skill caps.\r\n", ch);
 }
+

--- a/system/commands.dat
+++ b/system/commands.dat
@@ -2583,6 +2583,14 @@ Log         0
 End
 
 #COMMAND
+Name        skill~
+Code        do_skill
+Position    104
+Level       0
+Log         0
+End
+
+#COMMAND
 Name        pardon~
 Code        do_pardon
 Position    100


### PR DESCRIPTION
## Summary
- replace the old practice display with a lock-aware skill summary and add the skill lock command
- respect skill lock states across trainers, languages, racial unlocks, and mp-practice by routing through skill gain helpers
- expose detailed skill meter output and update prompts/scoreboard to show total skill usage instead of practice sessions

## Testing
- `make -f Makefile.devcc` *(fails: missing gcc.exe in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d95cdbe57c832781157805bcb0b17a