### PR TITLE
Honor skill caps during staff adjustments and migrate legacy data

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -30,10 +30,10 @@ D_FLAGS = -g2 -O $(M_FLAGS) $(PROF) $(SOLARIS_LINK)
 
 C_FILES = act_comm.c act_info.c act_move.c act_obj.c act_wiz.c ban.c android.c boards.c \
           build.c calendar.c chess.c clans.c color.c combat_messages.c comm.c comments.c const.c custom_slay.c \
-		    cyber.c db.c deity.c dns.c fight.c fishing.c grub.c handler.c hashstr.c hint.c hotboot.c \
+                    cyber.c db.c deity.c dns.c fight.c fishing.c grub.c handler.c hashstr.c hint.c hotboot.c \
           house.c imm_host.c interp.c liquids.c magic.c makeobjs.c mapout.c mapper.c mccp.c \
           misc.c mpxset.c mssp.c mud_comm.c mud_prog.c news.c planes.c player.c polymorph.c powerup.c \
-          racial_transformations.c renumber.c reset.c save.c services.c sha256.c shops.c skills.c special.c tables.c \
+          racial_transformations.c renumber.c reset.c save.c services.c sha256.c shops.c skill_training.c skills.c special.c tables.c \
           track.c update.c variables.c weather.c
 
 O_FILES := $(patsubst %.c,o/%.o,$(C_FILES))

--- a/src/mud.h
+++ b/src/mud.h
@@ -4980,6 +4980,8 @@ double get_skill( CHAR_DATA *ch, int sn );
 void   add_skill_tenths( CHAR_DATA *ch, int sn, int delta );
 void   normalize_skill_locks( CHAR_DATA *ch );
 void   recalc_skill_totals( CHAR_DATA *ch );
+void   enforce_skill_total_cap( CHAR_DATA *ch );
+void   migrate_legacy_skill_data( CHAR_DATA *ch );
 void   skill_gain( CHAR_DATA *ch, int sn, int DR, bool success, int context_flags );
 void   update_skill_meters( CHAR_DATA *ch, int skill_num, int old_level, int new_level );
 void   enhanced_dam_message_ex( CHAR_DATA *ch, CHAR_DATA *victim, int dam, unsigned int dt,

--- a/src/mud_comm.c
+++ b/src/mud_comm.c
@@ -2012,13 +2012,21 @@ void do_mp_practice( CHAR_DATA* ch, const char* argument )
    }
 
    if( max > victim->pcdata->skills[sn].value_tenths )
-      trainer_raise_skill_to( victim, sn, max );
-
-   if( victim->pcdata->skills[sn].value_tenths >= adept )
    {
-      victim->pcdata->skills[sn].value_tenths = adept;
-      act( AT_TELL, "$n tells you, 'You have learned all I know on this subject...'", ch, NULL, victim, TO_VICT );
+      int target = max;
+
+      if( !IS_IMMORTAL( victim ) && adept > 0 )
+         target = UMIN( target, adept );
+
+      if( !trainer_raise_skill_to( victim, sn, target ) )
+      {
+         act( AT_TELL, "$n tries to teach you, but you're unable to make further progress right now.", ch, NULL, victim, TO_VICT );
+         return;
+      }
    }
+
+   if( adept > 0 && victim->pcdata->skills[sn].value_tenths >= adept )
+      act( AT_TELL, "$n tells you, 'You have learned all I know on this subject...'", ch, NULL, victim, TO_VICT );
 }
 
 void do_mpstrew( CHAR_DATA* ch, const char* argument )

--- a/src/save.c
+++ b/src/save.c
@@ -1084,8 +1084,11 @@ bool load_char_obj( DESCRIPTOR_DATA * d, char *name, bool preload, bool copyover
    }
 
    /*
-    * Rebuild affected_by and RIS to catch errors - FB 
+    * Rebuild affected_by and RIS to catch errors - FB
     */
+   if( !IS_NPC( ch ) && ch->pcdata )
+      migrate_legacy_skill_data( ch );
+
    update_aris( ch );
    loading_char = NULL;
    return found;


### PR DESCRIPTION
## Summary
- add skill_training.c to the build and expose the meter update helpers
- enforce skill cap logic in sset, including new skillcap tuning and lock normalization helpers
- update mob practice scripts to train through shared helpers and migrate legacy players to the new system at load time

## Testing
- make *(fails: linker does not recognize --export-all-symbols in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d9670db9f4832795b7cff20425ea9f