### PR TITLE
Remove skill locks and cap while tuning meter rewards

### DIFF
--- a/src/act_comm.c
+++ b/src/act_comm.c
@@ -3518,12 +3518,6 @@ void do_languages( CHAR_DATA* ch, const char* argument )
 
       SKILL_STATE *state = &ch->pcdata->skills[sn];
 
-      if( state->lock_state == SKILL_LOCK_DOWN )
-      {
-         act( AT_TELL, "$n tells you 'Set that language to RAISE or HOLD before we continue.'", sch, NULL, ch, TO_VICT );
-         return;
-      }
-
       int before = state->value_tenths;
       int target = before + ( prct * 10 );
       target = UMIN( target, 990 );

--- a/src/act_info.c
+++ b/src/act_info.c
@@ -3620,19 +3620,6 @@ void do_practice( CHAR_DATA* ch, const char* argument )
    }
 }
 
-static const char *skill_lock_label( int lock_state )
-{
-   switch( lock_state )
-   {
-      case SKILL_LOCK_UP:
-         return "Raise";
-      case SKILL_LOCK_DOWN:
-         return "Down";
-      default:
-         return "Hold";
-   }
-}
-
 /*
  * Show the list of skills available for practice
  */
@@ -3775,12 +3762,6 @@ void practice_specific_skill( CHAR_DATA *ch, CHAR_DATA *mob, const char *argumen
 
    SKILL_STATE *state = &ch->pcdata->skills[sn];
 
-   if( state->lock_state == SKILL_LOCK_DOWN )
-   {
-      act( AT_TELL, "$n tells you 'Set that skill to RAISE or HOLD before I can help you.'", mob, NULL, ch, TO_VICT );
-      return;
-   }
-
    int adept = get_skill_adept( ch, sn );
    int practice_cap = UMIN( PRACTICE_MAX_TENTHS, adept );
 
@@ -3834,61 +3815,17 @@ void practice_specific_skill( CHAR_DATA *ch, CHAR_DATA *mob, const char *argumen
 
 void do_skill( CHAR_DATA *ch, const char *argument )
 {
-   char arg[MAX_INPUT_LENGTH];
-   char arg2[MAX_INPUT_LENGTH];
-   char arg3[MAX_INPUT_LENGTH];
-
    if( IS_NPC( ch ) )
       return;
 
-   argument = one_argument( argument, arg );
-
-   if( arg[0] == '\0' )
+   if( argument[0] == '\0' )
    {
       show_practice_list( ch, NULL );
       return;
    }
 
-   if( !str_cmp( arg, "lock" ) )
-   {
-      argument = one_argument( argument, arg2 );
-      argument = one_argument( argument, arg3 );
-
-      if( arg2[0] == '\0' || arg3[0] == '\0' )
-      {
-         send_to_char( "Usage: skill lock <skill> <up|down|hold>\\r\\n", ch );
-         return;
-      }
-
-      int sn = skill_lookup( arg2 );
-
-      if( sn < 0 || sn >= num_skills || !skill_table[sn] )
-      {
-         send_to_char( "That skill isn't recognized.\\r\\n", ch );
-         return;
-      }
-
-      signed char new_state;
-
-      if( !str_prefix( arg3, "up" ) || !str_prefix( arg3, "raise" ) )
-         new_state = SKILL_LOCK_UP;
-      else if( !str_prefix( arg3, "down" ) )
-         new_state = SKILL_LOCK_DOWN;
-      else if( !str_prefix( arg3, "hold" ) || !str_prefix( arg3, "lock" ) || !str_prefix( arg3, "steady" ) )
-         new_state = SKILL_LOCK_STEADY;
-      else
-      {
-         send_to_char( "Valid states are up, down, or hold.\\r\\n", ch );
-         return;
-      }
-
-      ch->pcdata->skills[sn].lock_state = new_state;
-      ch_printf( ch, "Skill &W%s&D lock set to &W%s&D.\\r\\n", skill_table[sn]->name, skill_lock_label( new_state ) );
-      return;
-   }
-
-   send_to_char( "Usage: skill\\r\\n", ch );
-   send_to_char( "       skill lock <skill> <up|down|hold>\\r\\n", ch );
+   send_to_char( "Usage: skill\r\n", ch );
+   send_to_char( "       Use the practice command with a trainer to advance specific skills.\r\n", ch );
 }
 
 

--- a/src/db.c
+++ b/src/db.c
@@ -3046,10 +3046,6 @@ void clear_char( CHAR_DATA * ch )
       ch->pcdata->cached_prof_bonus = 0;
       ch->pcdata->cached_prof_gsn = -1;
       ch->pcdata->skill_total_tenths = 0;
-      ch->pcdata->skill_cap_tenths = DEFAULT_SKILL_CAP_TENTHS;
-      ch->pcdata->skill_gain_pool = 0;
-      ch->pcdata->skill_gain_last_attempt = 0;
-      ch->pcdata->skill_gain_last_decay = 0;
       ch->pcdata->physical_skill_meter = 0;
       ch->pcdata->mental_skill_meter = 0;
    }

--- a/src/mud.h
+++ b/src/mud.h
@@ -2521,10 +2521,6 @@ struct ignore_data
 /*
  * Data which only PC's have.
  */
-#define SKILL_LOCK_DOWN     -1
-#define SKILL_LOCK_STEADY    0
-#define SKILL_LOCK_UP        1
-
 /* Context flags describing where a skill usage came from */
 #define SKILL_CONTEXT_NONE       0
 #define SKILL_CONTEXT_COMBAT     BV00
@@ -2535,14 +2531,10 @@ struct ignore_data
 #define SKILL_CONTEXT_ABILITY    BV05
 #define SKILL_CONTEXT_SCRIPT     BV06
 
-#define DEFAULT_SKILL_CAP_TENTHS 7000
-#define MAX_SKILL_CAP_TENTHS     (MAX_SKILL * 1000)
-
 typedef struct skill_state
 {
    short value_tenths;   /* Stored skill value in tenths of a percent */
    short cap_tenths;     /* Maximum attainable value in tenths */
-   signed char lock_state; /* See SKILL_LOCK_* constants */
    time_t last_used;     /* Timestamp of last use */
 } SKILL_STATE;
 
@@ -2589,10 +2581,6 @@ struct pc_data
    short condition[MAX_CONDS];
    SKILL_STATE skills[MAX_SKILL];
    int skill_total_tenths;
-   int skill_cap_tenths;
-   int skill_gain_pool;
-   time_t skill_gain_last_attempt;
-   time_t skill_gain_last_decay;
    int physical_skill_meter;
    int mental_skill_meter;
    unsigned int cyber; 								/* bitmask of installed cybernetics (CYBER_*) */
@@ -4969,7 +4957,6 @@ double get_skill( CHAR_DATA *ch, int sn );
 void   add_skill_tenths( CHAR_DATA *ch, int sn, int delta );
 void   normalize_skill_locks( CHAR_DATA *ch );
 void   recalc_skill_totals( CHAR_DATA *ch );
-void   enforce_skill_total_cap( CHAR_DATA *ch );
 void   migrate_legacy_skill_data( CHAR_DATA *ch );
 void   skill_gain( CHAR_DATA *ch, int sn, int DR, bool success, int context_flags );
 void   update_skill_meters( CHAR_DATA *ch, int skill_num, int old_level, int new_level );

--- a/src/mud_comm.c
+++ b/src/mud_comm.c
@@ -2016,12 +2016,6 @@ void do_mp_practice( CHAR_DATA* ch, const char* argument )
    act( AT_ACTION, "$N demonstrates $t to you.  You feel more learned in this subject.", victim, skill_table[sn]->name, ch,
         TO_CHAR );
 
-   if( victim->pcdata->skills[sn].lock_state == SKILL_LOCK_DOWN )
-   {
-      act( AT_TELL, "$n tries to teach you, but you've locked that skill down.", ch, NULL, victim, TO_VICT );
-      return;
-   }
-
    if( victim->gold < PRACTICE_SESSION_COST )
    {
       ch_printf( victim, "&RYou need %d gold to train, but you only have %d.&D\r\n", PRACTICE_SESSION_COST, victim->gold );

--- a/src/player.c
+++ b/src/player.c
@@ -343,9 +343,8 @@ void do_score( CHAR_DATA* ch, const char* argument )
    if( !IS_NPC( ch ) )
    {
       recalc_skill_totals( ch );
-      int skill_cap = ch->pcdata->skill_cap_tenths <= 0 ? DEFAULT_SKILL_CAP_TENTHS : ch->pcdata->skill_cap_tenths;
-      pager_printf( ch, "&cSKILL: &G%5.1f/%-5.1f&c             &cLife: &G%-5d \r\n&D",
-                    ch->pcdata->skill_total_tenths / 10.0, skill_cap / 10.0, ch->hit );
+      pager_printf( ch, "&cSKILL: &G%5.1f&c                &cLife: &G%-5d \r\n&D",
+                    ch->pcdata->skill_total_tenths / 10.0, ch->hit );
    }
    else
       pager_printf( ch, "&cSKILL: &G----&c             &cLife: &G%-5d \r\n&D", ch->hit );

--- a/src/skill_training.c
+++ b/src/skill_training.c
@@ -132,7 +132,7 @@ void update_skill_meters(CHAR_DATA *ch, int skill_num, int old_level, int new_le
             /* Check if meter filled (100% = 100 points) */
             while(ch->pcdata->physical_skill_meter >= 100) {
                 /* Award HP and reset meter */
-                int hp_bonus = 10 + (ch->pcdata->physical_skill_meter / 50); /* 10-12 HP */
+                int hp_bonus = number_range(6, 12); /* 6-12 HP */
                 ch->max_hit += hp_bonus;
                 ch->hit += hp_bonus; /* Also heal them */
                 
@@ -152,7 +152,7 @@ void update_skill_meters(CHAR_DATA *ch, int skill_num, int old_level, int new_le
             /* Check if meter filled */
             while(ch->pcdata->mental_skill_meter >= 100) {
                 /* Award Mana and reset meter */
-                int mana_bonus = 5 + (ch->pcdata->mental_skill_meter / 50); /* 5-7 mana */
+                int mana_bonus = number_range(2, 8); /* 2-8 mana */
                 ch->max_mana += mana_bonus;
                 ch->mana += mana_bonus; /* Also restore mana */
                 


### PR DESCRIPTION
## Summary
- remove skill lock state handling and the global skill cap so gains rely only on individual skill limits
- bump the save-file format to v8 to drop legacy lock/cap data while still loading older player files
- adjust skill meter rewards so physical gains grant 6-12 HP and mental gains grant 2-8 mana

## Testing
- make *(fails: no makefile present)*

------
https://chatgpt.com/codex/tasks/task_e_68d9799754d08327b83382fd88208b77