### PR TITLE
Remove unused locals flagged by compiler warnings

### DIFF
--- a/src/act_comm.c
+++ b/src/act_comm.c
@@ -3461,7 +3461,6 @@ void do_languages( CHAR_DATA* ch, const char* argument )
       char arg2[MAX_INPUT_LENGTH];
       int sn;
       int prct;
-      int prac;
 
       argument = one_argument( argument, arg2 );
       if( arg2[0] == '\0' )

--- a/src/skills.c
+++ b/src/skills.c
@@ -1284,7 +1284,6 @@ void do_slookup( CHAR_DATA* ch, const char* argument )
    char buf[MAX_STRING_LENGTH];
    char arg[MAX_INPUT_LENGTH];
    int sn;
-   int iClass, iRace;
    SKILLTYPE *skill = NULL;
 
    one_argument( argument, arg );
@@ -1469,7 +1468,7 @@ void do_sset( CHAR_DATA* ch, const char* argument )
    CHAR_DATA *victim;
    int value;
    int value_tenths;
-   int sn, i;
+   int sn;
    bool fAll;
    SKILLTYPE *skill;
 

--- a/src/tables.c
+++ b/src/tables.c
@@ -369,7 +369,6 @@ void write_race_file( int ra )
    char filename[MAX_INPUT_LENGTH];
    struct race_type *race = race_table[ra];
    int i;
-   int x, y;
 
    if( !race->race_name )
    {


### PR DESCRIPTION
## Summary
- remove unused temporary variables from language learning and skill commands
- drop unused loop counters from race file writer to prevent compiler warnings

## Testing
- make *(fails: linker on this environment does not understand `--export-all-symbols`)*

------
https://chatgpt.com/codex/tasks/task_e_68d99d4b12ec83278dce980ec92118d0