### PR TITLE
Remove skill total from score display

### DIFF
--- a/src/player.c
+++ b/src/player.c
@@ -340,14 +340,7 @@ void do_score( CHAR_DATA* ch, const char* argument )
          snprintf( buf, MAX_STRING_LENGTH, "%s", "standard" );
          break;
    }
-   if( !IS_NPC( ch ) )
-   {
-      recalc_skill_totals( ch );
-      pager_printf( ch, "&cSKILL: &G%5.1f&c                &cLife: &G%-5d \r\n&D",
-                    ch->pcdata->skill_total_tenths / 10.0, ch->hit );
-   }
-   else
-      pager_printf( ch, "&cSKILL: &G----&c             &cLife: &G%-5d \r\n&D", ch->hit );
+   pager_printf( ch, "&cLife: &G%-5d \r\n&D", ch->hit );
 
    pager_printf( ch, "&OGOLD : %-13s&c         &cMana: &C%d/%d&C&D \r\n", 
 				 num_punct( ch->gold ), ch->mana, ch->max_mana  );


### PR DESCRIPTION
## Summary
- remove the SKILL total line from the score sheet so only life is shown

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da068d7f308327af7c261a8bf89b46