### PR TITLE
Allow mortals to use the score command

### DIFF
--- a/system/commands.dat
+++ b/system/commands.dat
@@ -3176,7 +3176,7 @@ End
 Name        score~
 Code        do_score
 Position    100
-Level       2
+Level       0
 Log         0
 Flags       16
 End


### PR DESCRIPTION
## Summary
- lower the level requirement for the score command so regular players can use it

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da084e618c832796e46d64e13a4d29