### PR TITLE
Hide unpracticed skills from default slist output

### DIFF
--- a/src/act_info.c
+++ b/src/act_info.c
@@ -4907,11 +4907,10 @@ void do_slist( CHAR_DATA* ch, const char* argument )
 
          if( !show_all )
          {
-            if( learned_value <= 0 && SPELL_FLAG( skill, SF_SECRETSKILL ) )
+            if( learned_value <= 0 )
                continue;
 
-            if( skill->min_power_level > 0 && char_pl < skill->min_power_level
-                && learned_value <= 0 )
+            if( skill->min_power_level > 0 && char_pl < skill->min_power_level )
                continue;
          }
 


### PR DESCRIPTION
## Summary
- prevent `slist` from showing skills that a player has not yet learned unless `slist all` is used

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68da0d64f9148327a23707f41c2827ff