### PR TITLE
Restrict slist command to immortals

### DIFF
--- a/system/commands.dat
+++ b/system/commands.dat
@@ -3398,7 +3398,7 @@ End
 Name        slist~
 Code        do_slist
 Position    104
-Level       0
+Level       52
 Log         0
 End
 


### PR DESCRIPTION
## Summary
- restrict the `slist` command to immortals by raising its command level to 52

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da0e4ee1088327bfd5f6b5a1b7ed1e