### PR TITLE
Adjust mental state triggers

### DIFF
--- a/src/deity.c
+++ b/src/deity.c
@@ -1027,7 +1027,6 @@ void do_devote( CHAR_DATA* ch, const char* argument )
       if( ch->pcdata->deity->worshippers < 0 )
          ch->pcdata->deity->worshippers = 0;
       ch->pcdata->favor = -2500;
-      ch->mental_state = -80;
       send_to_char( "A terrible curse afflicts you as you forsake a deity!\r\n", ch );
       xREMOVE_BITS( ch->affected_by, ch->pcdata->deity->affected );
       REMOVE_BIT( ch->resistant, ch->pcdata->deity->element );

--- a/src/fight.c
+++ b/src/fight.c
@@ -2529,7 +2529,6 @@ ch_ret damage_ex( CHAR_DATA * ch, CHAR_DATA * victim, int dam, int dt, bool supp
       af.modifier = -2;
       af.bitvector = meb( AFF_POISON );
       affect_join( victim, &af );
-      victim->mental_state = URANGE( 20, victim->mental_state + ( IS_PKILL( victim ) ? 1 : 2 ), 100 );
    }
 
    /*
@@ -2583,14 +2582,10 @@ ch_ret damage_ex( CHAR_DATA * ch, CHAR_DATA * victim, int dam, int dt, bool supp
          if( dam > ( victim->max_hit / 4 ) )
          {
             act( AT_HURT, "That really did HURT!", victim, 0, 0, TO_CHAR );
-            if( number_percent( ) < ( 10 + ( dam / 20 ) ) )
-               worsen_mental_state( victim, 1 );
          }
          if( victim->hit < ( victim->max_hit / 4 ) )
          {
             act( AT_DANGER, "You wish that your wounds would stop BLEEDING so much!", victim, 0, 0, TO_CHAR );
-            if( number_percent( ) < ( 10 + ( dam / 20 ) ) )
-               worsen_mental_state( victim, 1 );
          }
          break;
    }

--- a/src/liquids.c
+++ b/src/liquids.c
@@ -1402,7 +1402,6 @@ void do_drink( CHAR_DATA* ch, const char* argument )
          {
             act( AT_POISON, "$n sputters and gags.", ch, NULL, NULL, TO_ROOM );
             act( AT_POISON, "You sputter and gag.", ch, NULL, NULL, TO_CHAR );
-            ch->mental_state = URANGE( 20, ch->mental_state + 5, 100 );
             af.type = gsn_poison;
             af.duration = obj->value[3];
             af.location = APPLY_NONE;
@@ -1495,7 +1494,6 @@ void do_drink( CHAR_DATA* ch, const char* argument )
          {
             act( AT_POISON, "$n sputters and gags.", ch, NULL, NULL, TO_ROOM );
             act( AT_POISON, "You sputter and gag.", ch, NULL, NULL, TO_CHAR );
-            ch->mental_state = URANGE( 20, ch->mental_state + 5, 100 );
             af.type = gsn_poison;
             af.duration = obj->value[3];
             af.location = APPLY_NONE;

--- a/src/misc.c
+++ b/src/misc.c
@@ -120,13 +120,11 @@ void do_eat( CHAR_DATA* ch, const char* argument )
                {
                   act( AT_POISON, "$n chokes and gags.", ch, NULL, NULL, TO_ROOM );
                   act( AT_POISON, "You choke and gag.", ch, NULL, NULL, TO_CHAR );
-                  ch->mental_state = URANGE( 20, ch->mental_state + 5, 100 );
                }
                else
                {
                   act( AT_POISON, "$n gags on $p.", ch, obj, NULL, TO_ROOM );
                   act( AT_POISON, "You gag on $p.", ch, obj, NULL, TO_CHAR );
-                  ch->mental_state = URANGE( 15, ch->mental_state + 5, 100 );
                }
 
                af.type = gsn_poison;

--- a/src/update.c
+++ b/src/update.c
@@ -953,7 +953,6 @@ void char_update( void )
          {
             act( AT_POISON, "$n shivers and suffers.", ch, NULL, NULL, TO_ROOM );
             act( AT_POISON, "You shiver and suffer.", ch, NULL, NULL, TO_CHAR );
-            ch->mental_state = URANGE( 20, ch->mental_state + ( IS_NPC( ch ) ? 2 : IS_PKILL( ch ) ? 3 : 4 ), 100 );
             damage( ch, ch, 6, gsn_poison );
          }
          else if( ch->position == POS_INCAP )


### PR DESCRIPTION
## Summary
- remove the mental state penalty when a player renounces their deity
- stop food and drink poison from directly modifying mental state and rely on existing status effects
- eliminate combat and update loop mental state adjustments from weapon poison and heavy damage events

## Testing
- not run (manual testing required in-game)


------
https://chatgpt.com/codex/tasks/task_e_68dab411685483279b4dea1d974fce31