### PR TITLE
Set new character starting room to vnum 200

### DIFF
--- a/src/comm.c
+++ b/src/comm.c
@@ -2606,7 +2606,7 @@ void nanny_read_motd( DESCRIPTOR_DATA * d, const char *argument )
          }
       }
       if( !sysdata.WAIT_FOR_AUTH )
-         char_to_room( ch, get_room_index( ROOM_VNUM_SCHOOL ) );
+         char_to_room( ch, get_room_index( ROOM_VNUM_NEW_CHAR ) );
       else
       {
          char_to_room( ch, get_room_index( ROOM_AUTH_START ) );

--- a/src/mud.h
+++ b/src/mud.h
@@ -1971,6 +1971,7 @@ typedef enum
 #define ROOM_VNUM_TEMPLE	  21001
 #define ROOM_VNUM_ALTAR		  21194
 #define ROOM_VNUM_SCHOOL	  10300
+#define ROOM_VNUM_NEW_CHAR          200
 #define ROOM_AUTH_START		    100
 #define ROOM_VNUM_HALLOFFALLEN    21195
 #define ROOM_VNUM_DEADLY       3009


### PR DESCRIPTION
## Summary
- add a dedicated constant for the new-character starting room
- route freshly created characters to room vnum 200 when auto-placing them in the world

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dabe08d9e8832796cb4a1315b627cf