### PR TITLE
Fix slist access and adjust skill command

### DIFF
--- a/src/act_info.c
+++ b/src/act_info.c
@@ -3822,7 +3822,15 @@ void do_skill( CHAR_DATA *ch, const char *argument )
 
    if( argument[0] == '\0' )
    {
-      show_practice_list( ch, NULL );
+      if( IS_IMMORTAL( ch ) )
+      {
+         show_practice_list( ch, NULL );
+      }
+      else
+      {
+         send_to_char( "You need to seek out a trainer and ask what they can teach.\r\n", ch );
+         send_to_char( "Trainers can then help you practice specific skills.\r\n", ch );
+      }
       return;
    }
 

--- a/system/commands.dat
+++ b/system/commands.dat
@@ -3398,7 +3398,7 @@ End
 Name        slist~
 Code        do_slist
 Position    104
-Level       52
+Level       0
 Log         0
 End
 


### PR DESCRIPTION
## Summary
- allow mortals to use the slist command again by lowering its command level requirement
- update the skill command so mortals are directed to speak with trainers while immortals retain the old list view

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dad3c36f0c832781575cf3965a3364