### PR TITLE
Add gather skill context and flag

### DIFF
--- a/src/mud.h
+++ b/src/mud.h
@@ -1686,6 +1686,7 @@ typedef enum
 #define SF_NOMOB		  	BV22   /* cannot be cast on mobiles */
 #define SF_BASICSKILL     	BV23   /* Always shown on practice lists */
 #define SF_RACESKILL      	BV24   /* Race-specific skills, shown if race can use */
+#define SF_GATHERSKILL    	BV25   /* Gathering-focused ability */
 typedef enum
 { SS_NONE, SS_POISON_DEATH, SS_ROD_WANDS, SS_PARA_PETRI,
    SS_BREATH, SS_SPELL_STAFF
@@ -2537,7 +2538,8 @@ struct ignore_data
 #define SKILL_CONTEXT_SOCIAL     BV03
 #define SKILL_CONTEXT_STEALTH    BV04
 #define SKILL_CONTEXT_ABILITY    BV05
-#define SKILL_CONTEXT_SCRIPT     BV06
+#define SKILL_CONTEXT_GATHER     BV06
+#define SKILL_CONTEXT_SCRIPT     BV07
 
 typedef struct skill_state
 {

--- a/src/skills.c
+++ b/src/skills.c
@@ -127,6 +127,9 @@ static int infer_skill_context( int sn )
 
    const struct skill_type *skill = skill_table[sn];
 
+   if( skill->flags & SF_GATHERSKILL )
+      return SKILL_CONTEXT_GATHER;
+
    switch( skill->type )
    {
       case SKILL_SPELL:
@@ -323,6 +326,8 @@ void skill_gain( CHAR_DATA *ch, int sn, int DR, bool success, int context_flags 
 
    if( resolved_context & SKILL_CONTEXT_CRAFT )
       base_chance += 3;
+   if( resolved_context & SKILL_CONTEXT_GATHER )
+      base_chance += 3;
    if( resolved_context & SKILL_CONTEXT_MAGIC )
       base_chance -= 2;
    if( resolved_context & SKILL_CONTEXT_SOCIAL )
@@ -418,7 +423,8 @@ const char *const spell_flag[] = {
    "nomob",          // 22 - SF_NOMOB (BV22)
    "basicskill",     // 23 - SF_BASICSKILL (BV23)
    "raceskill",      // 24 - SF_RACESKILL (BV24)
-   "r5", "r6", "r7", "r8", "r9", "r10", "r11"
+   "gatherskill",    // 25 - SF_GATHERSKILL (BV25)
+   "r5", "r6", "r7", "r8", "r9", "r10"
 };
 
 const char *const spell_saves[] = { "none", "poison_death", "wands", "para_petri", "breath", "spell_staff" };

--- a/system/skills.dat
+++ b/system/skills.dat
@@ -515,7 +515,7 @@ End
 Name         dig~
 Type         Skill
 Info         0
-Flags        0
+Flags        gatherskill
 Minpos       112
 Rounds       20
 Code         do_dig
@@ -1429,7 +1429,7 @@ End
 Name         fishing~
 Type         Skill
 Info         0
-Flags        0
+Flags        gatherskill
 Rounds       12
 Code         do_fish
 Dammsg       fishing attempt~


### PR DESCRIPTION
## Summary
- add a dedicated SKILL_CONTEXT_GATHER bit and accompanying SF_GATHERSKILL flag
- expose the new gatherskill flag name and update context inference and gain logic
- mark dig and fishing skills as gathering-focused in the data file

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68daef5e26908327b5f3eeef437edb68