### PR TITLE
Add mining gathering skill with configurable ore difficulties

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -425,8 +425,9 @@ void boot_db( bool fCopyOver )
    remap_slot_numbers(  ); /* must be after the sort */
    
    num_sorted_skills = num_skills;
-	init_racial_transformations();
-	init_fishing_skill();
+   init_racial_transformations();
+   init_fishing_skill();
+   init_mining_skill();
 	
    log_string( "Loading classes" );
    load_classes(  );

--- a/src/mud.h
+++ b/src/mud.h
@@ -4577,6 +4577,9 @@ extern "C" {
 void do_fish(CHAR_DATA *ch, const char *argument);
 void init_fishing_skill(void);
 void do_fishdb(CHAR_DATA *ch, const char *argument);
+void do_mine(CHAR_DATA *ch, const char *argument);
+void init_mining_skill(void);
+void do_oredb(CHAR_DATA *ch, const char *argument);
 void init_gathering_system(void);
 void set_gather_task_difficulty(const char *skill, const char *task, int difficulty, int min_skill);
 bool get_gather_task_difficulty(const char *skill, const char *task, int *difficulty, int *min_skill);

--- a/system/skills.dat
+++ b/system/skills.dat
@@ -1438,6 +1438,18 @@ Minlevel     0
 End
 
 #SKILL
+Name         mining~
+Type         Skill
+Info         0
+Flags        gatherskill
+Rounds       18
+Code         do_mine
+Dammsg       mining attempt~
+Wearoff      Your arms stop aching from mining.~
+Minlevel     0
+End
+
+#SKILL
 Name         block~
 Type         Skill
 Info         0


### PR DESCRIPTION
## Summary
- add a mining subsystem to gathering.c with ore definitions, selection logic, tool checks, and an immortal oreb listing command
- register the mining skill during boot, expose the new interfaces, and wire a mining command with dynamic difficulty handling
- add a mining skill entry to the skills data file flagged as a gathering skill

## Testing
- make *(interrupted after verifying new object files compiled)*

------
https://chatgpt.com/codex/tasks/task_e_68db0ad32b2c8327aaa4622d84ba4b25