### PR TITLE
Remove obsolete skill listing command

### DIFF
--- a/src/act_info.c
+++ b/src/act_info.c
@@ -3815,33 +3815,6 @@ void practice_specific_skill( CHAR_DATA *ch, CHAR_DATA *mob, const char *argumen
    }
 }
 
-void do_skill( CHAR_DATA *ch, const char *argument )
-{
-   if( IS_NPC( ch ) )
-      return;
-
-   if( argument[0] == '\0' )
-   {
-      if( IS_IMMORTAL( ch ) )
-      {
-         show_practice_list( ch, NULL );
-      }
-      else
-      {
-         send_to_char( "You need to seek out a trainer and ask what they can teach.\r\n", ch );
-         send_to_char( "Trainers can then help you practice specific skills.\r\n", ch );
-      }
-      return;
-   }
-
-   send_to_char( "Usage: skill\r\n", ch );
-   send_to_char( "       Use the practice command with a trainer to advance specific skills.\r\n", ch );
-}
-
-
-
-
-
 /*
  * Check if a trainer can teach a specific hidden skill
  */

--- a/src/mud.h
+++ b/src/mud.h
@@ -4206,7 +4206,6 @@ DECLARE_DO_FUN( do_pounce );
 DECLARE_DO_FUN( do_powerup );
 DECLARE_DO_FUN( do_powerdown );
 DECLARE_DO_FUN( do_practice );
-DECLARE_DO_FUN( do_skill );
 DECLARE_DO_FUN( do_project );
 DECLARE_DO_FUN( do_prompt );
 DECLARE_DO_FUN( do_pset );

--- a/system/commands.dat
+++ b/system/commands.dat
@@ -2583,14 +2583,6 @@ Log         0
 End
 
 #COMMAND
-Name        skill~
-Code        do_skill
-Position    104
-Level       0
-Log         0
-End
-
-#COMMAND
 Name        pardon~
 Code        do_pardon
 Position    100


### PR DESCRIPTION
## Summary
- remove the `skill` command implementation that duplicated practice listings
- delete the corresponding command declaration and data entry so the command is no longer registered

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68db4e4d2654832786bff231b246a065