### PR TITLE
Add guards for directory access in color themes and hotboot loader

### DIFF
--- a/src/color.c
+++ b/src/color.c
@@ -147,6 +147,13 @@ void show_colorthemes( CHAR_DATA * ch )
    send_to_pager( "&YThe following themes are available:\r\n", ch );
 
    dp = opendir( COLOR_DIR );
+   if( !dp )
+   {
+      log_printf( "%s: unable to open color directory %s", __func__, COLOR_DIR );
+      send_to_pager( "Color theme directory is unavailable.\r\n", ch );
+      return;
+   }
+
    dentry = readdir( dp );
    while( dentry )
    {

--- a/src/hotboot.c
+++ b/src/hotboot.c
@@ -509,6 +509,12 @@ void load_obj_files( void )
    log_string( "World state: loading objs" );
    snprintf( directory_name, 100, "%s", HOTBOOT_DIR );
    dp = opendir( directory_name );
+   if( !dp )
+   {
+      log_printf_plus( LOG_WARN, sysdata.log_level, "%s: unable to open hotboot directory %s", __func__, directory_name );
+      return;
+   }
+
    dentry = readdir( dp );
    while( dentry )
    {


### PR DESCRIPTION
## Summary
- handle failures to open the color theme directory by logging and informing the caller
- log a warning when the hotboot object directory cannot be opened and skip scanning

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dc04d970448327b472fd52398c37c9