### PR TITLE
Fix Eldari meditation occupant detection

### DIFF
--- a/src/skills.c
+++ b/src/skills.c
@@ -3629,16 +3629,33 @@ void do_meditate( CHAR_DATA * ch, const char *argument )
               send_to_char( "&RYour mind cannot focus during combat!&x\r\n", ch );
               discovery_chance = 0;  /* No discovery chance while fighting */
           }
-          else if( ch->in_room->first_person != ch && ch->in_room->first_person->next_in_room )
-          {
-              /* Other people in room reduce concentration */
-              discovery_chance /= 3;  /* Much lower chance if not alone */
-              send_to_char( "&YThe presence of others disrupts your deep meditation.&x\r\n", ch );
-          }
           else
           {
-              /* Perfect meditation environment */
-              send_to_char( "&CYou find perfect stillness and focus in your solitude.&x\r\n", ch );
+              bool others_present = false;
+
+              if( ch->in_room )
+              {
+                  for( CHAR_DATA *rch = ch->in_room->first_person; rch; rch = rch->next_in_room )
+                  {
+                      if( rch == ch )
+                         continue;
+
+                      others_present = true;
+                      break;
+                  }
+              }
+
+              if( others_present )
+              {
+                  /* Other people in room reduce concentration */
+                  discovery_chance /= 3;  /* Much lower chance if not alone */
+                  send_to_char( "&YThe presence of others disrupts your deep meditation.&x\r\n", ch );
+              }
+              else
+              {
+                  /* Perfect meditation environment */
+                  send_to_char( "&CYou find perfect stillness and focus in your solitude.&x\r\n", ch );
+              }
           }
           
           /* Check for transformation discovery */


### PR DESCRIPTION
## Summary
- scan the full room occupant list during Eldari meditation to detect any other characters
- adjust concentration penalties and messaging to trigger whenever another person is present

## Testing
- ⚠️ `make -f Makefile.devcc` *(fails: gcc.exe not available in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dc1a05e7708327af2cf84fe59406c3