### PR TITLE
Adjust android component drops for solo kills

### DIFF
--- a/src/android.c
+++ b/src/android.c
@@ -125,13 +125,16 @@ void check_android_components( CHAR_DATA *ch, CHAR_DATA *victim )
         return;
     
     /* Group vs solo rates */
-    if( is_same_group(android, ch) )
+    if( android == ch )
+    {
+        if( !android->leader )
+            drop_chance = 1;  /* 1% for solo, only if android killed the enemy */
+        else
+            drop_chance = 2;  /* Leader present implies groupmates involved */
+    }
+    else if( is_same_group(android, ch) )
     {
         drop_chance = 2;  /* 2% for group */
-    }
-    else if( !android->leader && android == ch )
-    {
-        drop_chance = 1;  /* 1% for solo, only if android killed the enemy */
     }
     
     /* Check for drop */


### PR DESCRIPTION
## Summary
- ensure solo android kill drop logic runs before group detection
- preserve 1% drop chance for solo androids without leaders and 2% for grouped kills

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68dc1d8654188327b572df6e9120cb09