### PR TITLE
Free temporary meditation/trance buffers after reuse

### DIFF
--- a/src/skills.c
+++ b/src/skills.c
@@ -3511,7 +3511,7 @@ void do_rescue( CHAR_DATA* ch, const char* argument )
 
 void do_meditate( CHAR_DATA * ch, const char *argument )
 {
-   char *arg;
+   char *arg = NULL;
    int percent;
    int managain = ( IS_ELDARI(ch) ? 0 : 22 ); //was druid... potential change
 
@@ -3715,18 +3715,27 @@ void do_meditate( CHAR_DATA * ch, const char *argument )
       TIMER *timer;
       timer = get_timerptr( ch, TIMER_DO_FUN );
       timer->count += UMAX( 2, ( skill_table[gsn_meditate]->beats / 8 ) );
-      ch->alloc_ptr = strdup( arg );
+      if( arg )
+         ch->alloc_ptr = strdup( arg );
+      else
+         ch->alloc_ptr = NULL;
    }
    else
    {
       send_to_char_color( "&BYou complete your meditations.\r\n", ch );
       ch->substate = SUB_NONE;
    }
+
+   if( arg )
+   {
+      DISPOSE( arg );
+      arg = NULL;
+   }
 }
 
 void do_trance( CHAR_DATA * ch, const char *argument )
 {
-   char *arg;
+   char *arg = NULL;
    int percent;
    int managain = ( IS_ELDARI(ch) ? 0 : 50 ); // was druid... potential change
 
@@ -3821,12 +3830,21 @@ void do_trance( CHAR_DATA * ch, const char *argument )
       TIMER *timer;
       timer = get_timerptr( ch, TIMER_DO_FUN );
       timer->count += UMAX( 2, ( skill_table[gsn_trance]->beats / 8 ) );
-      ch->alloc_ptr = strdup( arg );
+      if( arg )
+         ch->alloc_ptr = strdup( arg );
+      else
+         ch->alloc_ptr = NULL;
    }
    else
    {
       send_to_char_color( "&BYou complete your trance.\r\n", ch );
       ch->substate = SUB_NONE;
+   }
+
+   if( arg )
+   {
+      DISPOSE( arg );
+      arg = NULL;
    }
 }
 


### PR DESCRIPTION
## Summary
- free the temporary duplicate used in meditate/trance loops after copying it back to alloc_ptr
- guard the repeated alloc_ptr assignment in both skills when no argument string is available

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dc1e345150832790253b678c55c4e2