### PR TITLE
Use android macro in powerup effects

### DIFF
--- a/src/powerup.c
+++ b/src/powerup.c
@@ -79,7 +79,7 @@ void apply_powerup_effects( CHAR_DATA *ch, short powerup_tier )
      * The multiplier effect is applied in get_power_level() function */
     
     /* Visual effects based on race - adjust race checks as needed */
-    if( ch->race == 1 )  /* Change this number to match your android race number */
+    if( IS_ANDROID(ch) )
     {
         switch( powerup_tier )
         {


### PR DESCRIPTION
## Summary
- replace the hard-coded android race comparison in powerup effects with the IS_ANDROID helper so android characters use the mechanical visuals
- leave the existing organic messaging branch untouched for non-android races

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc258415d48327aab8c2d98deb7a89