### PR TITLE
Harden wildcard trimming in ban commands

### DIFF
--- a/doc/mental_state_regression.md
+++ b/doc/mental_state_regression.md
@@ -1,9 +1,12 @@
-# Mental State Regression Checks
+# Regression Checklists
 
 These focused checks ensure mental-state modifiers behave predictably after the
-changes to poison, confusion-style affects, and sobriety recovery.
+changes to poison, confusion-style affects, and sobriety recovery, and that the
+ban/allow command pair safely handles wildcard input.
 
-## Poison application and curing
+## Mental state regression checks
+
+### Poison application and curing
 
 1. Create or load a mortal test character with the `poison` spell available.
 2. Note the character's current mental state via `mstat self` (expect roughly
@@ -14,7 +17,7 @@ changes to poison, confusion-style affects, and sobriety recovery.
 4. Cast `cure poison self` and verify the poison affect clears and the mental
    state immediately returns to its pre-poison value.
 
-## SMAUG confusion/mania-style effects
+### SMAUG confusion/mania-style effects
 
 1. Using an imm-test character, create a SMAUG spell that applies
    `AFF_POISON` (e.g., through `sset` with `smaug affect poison` data) and set a
@@ -24,7 +27,26 @@ changes to poison, confusion-style affects, and sobriety recovery.
 3. Wait for the affect to expire or dispel it and verify the mental state drops
    back to its original baseline automatically.
 
-## Sobriety recovery
+### Sobriety recovery
+
+## Ban and allow wildcard regression
+
+1. Log in as an immortal capable of banning sites (for example, `trust <name>
+   110`).
+2. Run: `ban site * all`
+   - The command should reject the request with `You must include more than a
+     wildcard.`
+   - The MUD remains responsive and does not crash.
+3. Verify that `ban site` still lists existing entries to ensure the command
+   continues functioning after the rejection.
+4. Create a temporary ban to remove later (for example,
+   `ban site test.example mortal`).
+5. Attempt to remove all bans with a wildcard-only argument: `allow site *`
+   - The command should respond with `You must include more than a wildcard.`
+   - Existing bans are unchanged (`ban site` still shows the entry created in
+     step 4).
+6. Remove the temporary ban normally using either the ban number or the exact
+   hostname to confirm normal operation still works.
 
 1. Raise the character's drunk condition above `8` (e.g., `quaff beer` until the
    condition message indicates intoxication).

--- a/src/ban.c
+++ b/src/ban.c
@@ -441,11 +441,41 @@ void do_ban( CHAR_DATA* ch, const char* argument )
 
       if( !str_cmp( arg2, "site" ) )
       {
+         size_t len;
+
          pban = first_ban;
          if( temp[0] == '*' )
+         {
             temp++;
-         if( temp[strlen( temp ) - 1] == '*' )
-            temp[strlen( temp ) - 1] = '\0';
+            if( temp[0] == '\0' )
+            {
+               send_to_char( "You must include more than a wildcard for that search.\r\n", ch );
+               return;
+            }
+         }
+
+         len = strlen( temp );
+         if( len == 0 )
+         {
+            send_to_char( "You must include more than a wildcard for that search.\r\n", ch );
+            return;
+         }
+
+         if( temp[len - 1] == '*' )
+         {
+            if( len == 1 )
+            {
+               send_to_char( "You must include more than a wildcard for that search.\r\n", ch );
+               return;
+            }
+
+            temp[len - 1] = '\0';
+            if( temp[0] == '\0' )
+            {
+               send_to_char( "You must include more than a wildcard for that search.\r\n", ch );
+               return;
+            }
+         }
       }
       else if( !str_cmp( arg2, "class" ) )
          pban = first_ban_class;
@@ -528,18 +558,53 @@ void do_allow( CHAR_DATA* ch, const char* argument )
    {
       if( !value )
       {
+         size_t len;
+
          if( strlen( arg2 ) < 2 )
          {
-            send_to_char( "You have to have at least 2 chars for a ban\r\n", ch );
-            send_to_char( "If you are trying to allow by number use #\r\n", ch );
+            if( arg2[0] == '*' )
+               send_to_char( "You must include more than a wildcard.\r\n", ch );
+            else
+            {
+               send_to_char( "You have to have at least 2 chars for a ban\r\n", ch );
+               send_to_char( "If you are trying to allow by number use #\r\n", ch );
+            }
             return;
          }
 
          temp = arg2;
          if( arg2[0] == '*' )
+         {
             temp++;
-         if( temp[strlen( temp ) - 1] == '*' )
-            temp[strlen( temp ) - 1] = '\0';
+            if( temp[0] == '\0' )
+            {
+               send_to_char( "You must include more than a wildcard.\r\n", ch );
+               return;
+            }
+         }
+
+         len = strlen( temp );
+         if( len == 0 )
+         {
+            send_to_char( "You must include more than a wildcard.\r\n", ch );
+            return;
+         }
+
+         if( temp[len - 1] == '*' )
+         {
+            if( len == 1 )
+            {
+               send_to_char( "You must include more than a wildcard.\r\n", ch );
+               return;
+            }
+
+            temp[len - 1] = '\0';
+            if( temp[0] == '\0' )
+            {
+               send_to_char( "You must include more than a wildcard.\r\n", ch );
+               return;
+            }
+         }
       }
 
       for( pban = first_ban; pban; pban = pban->next )
@@ -925,7 +990,7 @@ int add_ban( CHAR_DATA * ch, const char *arg1, const char *arg2, int btime, int 
             {
                bool prefix = FALSE, suffix = FALSE, user_name = FALSE;
                char *temp_host = NULL, *temp_user = NULL;
-               size_t x;
+               size_t x, len;
 
                for( x = 0; x < strlen( arg ); x++ )
                {
@@ -961,12 +1026,66 @@ int add_ban( CHAR_DATA * ch, const char *arg1, const char *arg2, int btime, int 
                {
                   prefix = TRUE;
                   name++;
+                  if( name[0] == '\0' )
+                  {
+                     if( user_name )
+                     {
+                        DISPOSE( temp_host );
+                        DISPOSE( temp_user );
+                     }
+                     send_to_char( "You must include more than a wildcard.\r\n", ch );
+                     return 0;
+                  }
                }
 
-               if( name[strlen( name ) - 1] == '*' )
+               if( name[0] == '\0' )
                {
+                  if( user_name )
+                  {
+                     DISPOSE( temp_host );
+                     DISPOSE( temp_user );
+                  }
+                  send_to_char( "You must include more than a wildcard.\r\n", ch );
+                  return 0;
+               }
+
+               len = strlen( name );
+               if( len == 0 )
+               {
+                  if( user_name )
+                  {
+                     DISPOSE( temp_host );
+                     DISPOSE( temp_user );
+                  }
+                  send_to_char( "You must include more than a wildcard.\r\n", ch );
+                  return 0;
+               }
+
+               if( name[len - 1] == '*' )
+               {
+                  if( len == 1 )
+                  {
+                     if( user_name )
+                     {
+                        DISPOSE( temp_host );
+                        DISPOSE( temp_user );
+                     }
+                     send_to_char( "You must include more than a wildcard.\r\n", ch );
+                     return 0;
+                  }
+
                   suffix = TRUE;
-                  name[strlen( name ) - 1] = '\0';
+                  name[len - 1] = '\0';
+                  if( name[0] == '\0' )
+                  {
+                     if( user_name )
+                     {
+                        DISPOSE( temp_host );
+                        DISPOSE( temp_user );
+                     }
+                     send_to_char( "You must include more than a wildcard.\r\n", ch );
+                     return 0;
+                  }
                }
                for( temp = first_ban; temp; temp = temp->next )
                {


### PR DESCRIPTION
## Summary
- guard the `ban show`, `allow site`, and `add_ban` wildcard trimming paths against empty strings before touching the last character
- reject wildcard-only input deterministically so `ban`/`allow` never index before the buffer
- fold the ban wildcard regression notes into the existing regression checklist and drop the extra document

## Testing
- `make` *(fails: `/usr/bin/ld: unrecognized option '--export-all-symbols'`)*

------
https://chatgpt.com/codex/tasks/task_e_68dc45718754832786c11ffa496e9b6d