### PR TITLE
Add workstation item type for crafting fixtures

### DIFF
--- a/area/help.are
+++ b/area/help.are
@@ -14156,7 +14156,7 @@ See MAKESHOP, SHOPSET and SHOPS.
 
 51 SHOPVALUES~
 Syntax: shopset <mobile vnum> buy# <value>
- 
+
 1  - light               21 - pen                41 - rune
 2  - scroll              22 - boat               42 - runepouch
 3  - wand                23 - corpse             43 - match
@@ -14170,13 +14170,22 @@ Syntax: shopset <mobile vnum> buy# <value>
 11 - resource            31 - herbcon            51 - disease
 12 - furniture           32 - herb               52 - oil
 13 - trash               33 - incense            53 - fuel
-14 - gatheringbait       34 - fire               54 - shortbow
+14 - workstation        34 - fire               54 - shortbow
 15 - container           35 - book               55 - longbow
 16 - _note               36 - switch             56 - crossbow
 17 - drinkcon            37 - lever              57 - projectile
 18 - key                 38 - pullchain          58 - quiver
 19 - food                39 - button             59 - shovel
 20 - money               40 - dial               60 - salve
+~
+
+51 WORKSTATION~
+Workstations represent stationary crafting fixtures such as looms, anvils,
+and spinning wheels.  Builders can assign this item type to objects that
+should act as the anchor for crafting recipes or professions.  Use
+"workstation" as the type keyword when creating the object with OSET or
+in area files.  Workstations are typically non-portable furniture pieces
+that characters interact with while performing crafting commands.
 ~
 
 1 SHOULDER~

--- a/doc/Mob.help
+++ b/doc/Mob.help
@@ -429,7 +429,7 @@ Example: shopset 1000 buy1 8         [Mob will buy Treasures]
 11 - resource            31 - herbcon            51 - disease
 12 - furniture           32 - herb               52 - oil
 13 - trash               33 - incense            53 - fuel
-14 - gatheringbait       34 - fire               54 - shortbow
+14 - workstation        34 - fire               54 - shortbow
 15 - container           35 - book               55 - longbow
 16 - _note               36 - switch             56 - crossbow
 17 - drinkcon            37 - lever              57 - projectile

--- a/src/build.c
+++ b/src/build.c
@@ -106,7 +106,7 @@ const char *const area_flags[] = {
 
 const char *const o_types[] = {
    "none", "light", "scroll", "wand", "staff", "weapon", "materia", "gatheringtool",
-   "treasure", "armor", "potion", "resource", "furniture", "trash", "gatheringbait",
+   "treasure", "armor", "potion", "resource", "furniture", "trash", "workstation",
    "container", "_note", "drinkcon", "key", "food", "money", "pen", "boat",
    "corpse", "corpse_pc", "fountain", "pill", "blood", "bloodstain",
    "scraps", "relic", "herbcon", "herb", "incense", "fire", "book", "switch",

--- a/src/db.c
+++ b/src/db.c
@@ -2841,7 +2841,7 @@ OBJ_DATA *create_object( OBJ_INDEX_DATA * pObjIndex, int level )
       case ITEM_TREASURE:
       case ITEM_RESOURCE:
       case ITEM_GATHERING_TOOL:
-      case ITEM_GATHERING_BAIT:
+      case ITEM_WORKSTATION:
       case ITEM_FURNITURE:
       case ITEM_TRASH:
       case ITEM_CONTAINER:

--- a/src/mud.h
+++ b/src/mud.h
@@ -1815,7 +1815,7 @@ typedef enum
    ITEM_TREASURE, ITEM_ARMOR, ITEM_POTION,
    ITEM_RESOURCE,      /* Raw materials and harvested resources        */
    ITEM_FURNITURE, ITEM_TRASH,
-   ITEM_GATHERING_BAIT, /* Fishing bait, gathering lures, consumables  */
+   ITEM_WORKSTATION, /* Crafting workstations (looms, anvils, wheels) */
    ITEM_CONTAINER,
    ITEM_NOTE, ITEM_DRINK_CON, ITEM_KEY, ITEM_FOOD, ITEM_MONEY, ITEM_PEN,
    ITEM_BOAT, ITEM_CORPSE_NPC, ITEM_CORPSE_PC, ITEM_FOUNTAIN, ITEM_PILL,


### PR DESCRIPTION
## Summary
- replace the retired gathering bait enum with a new ITEM_WORKSTATION type for crafting fixtures
- remove bait selection and difficulty adjustments from the fishing flow now that bait items no longer exist
- update builder help tables and add a workstation help entry so designers know how to use the new type

## Testing
- make -C src o/gathering.o -s

------
https://chatgpt.com/codex/tasks/task_e_68df2336ee1083278246fb6343b9a71b