### PR TITLE
Fix highest-tier PL scaling threshold

### DIFF
--- a/src/update.c
+++ b/src/update.c
@@ -146,11 +146,11 @@ void gain_pl( CHAR_DATA *ch, long long gain, bool show_message )
          gain = (gain * sysdata.peaceful_exp_mod) / 100;
       
       /* DBSC-style power level scaling - apply LAST */
-		if( current_pl > 100000000000LL )    /* 1 trillion+ PL */
+      if( current_pl > 1000000000000LL )   /* 1 trillion+ PL */
          gain = gain * 15 / 100;           /* 85% reduction */
-		if( current_pl > 100000000000LL )    /* 100 billion+ PL */
+      else if( current_pl > 100000000000LL ) /* 100 billion+ PL */
          gain = gain / 4;                  /* 75% reduction */
-      if( current_pl > 1000000000LL )      /* 1 billion+ PL */
+      else if( current_pl > 1000000000LL ) /* 1 billion+ PL */
          gain = gain / 3;                  /* 66% reduction */
       else if( current_pl > 100000000LL )  /* 100 million+ PL */
          gain = gain * 2 / 3;              /* 33% reduction */


### PR DESCRIPTION
## Summary
- correct the top-end power-level scaling threshold in `gain_pl` to trigger at 1 trillion
- convert the scaling checks into an `else if` chain so only one tier is applied and update the tier comments

## Testing
- `make -C src` *(fails: /usr/bin/ld: unrecognized option '--export-all-symbols')*
- `python - <<'PY' ...`

------
https://chatgpt.com/codex/tasks/task_e_68e005c7a24083279dad73342ea77dd3