### PR TITLE
Add energy color customization and aura effects

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -3158,6 +3158,8 @@ void free_char( CHAR_DATA * ch )
       STRFREE( ch->pcdata->authed_by );
       STRFREE( ch->pcdata->prompt );
       STRFREE( ch->pcdata->fprompt );
+      if( ch->pcdata->energy_color )
+         STRFREE( ch->pcdata->energy_color );
       if( ch->pcdata->helled_by )
          STRFREE( ch->pcdata->helled_by );
       if( ch->pcdata->subprompt )

--- a/src/magic.c
+++ b/src/magic.c
@@ -5597,6 +5597,14 @@ ch_ret spell_attack( int sn, int level, CHAR_DATA * ch, void *vo )
    int dam;
    ch_ret retcode = rNONE;
 
+   if( skill && skill->name && !str_cmp( skill->name, "energy blast" ) )
+   {
+      act( AT_MAGIC, "{A}Ki crackles{x} around your palms as you gather a blazing sphere!", ch, NULL, victim, TO_CHAR );
+      act( AT_MAGIC, "$n's hands ignite with {A}energy{x} as $e draws power together!", ch, NULL, victim, TO_NOTVICT );
+      if( victim && victim != ch )
+         act( AT_MAGIC, "$n hurls a searing bolt of {A}energy{x} straight at you!", ch, NULL, victim, TO_VICT );
+   }
+
    if( saved && SPELL_SAVE( skill ) == SE_NEGATE )
    {
       failed_casting( skill, ch, victim, NULL );

--- a/src/mud.h
+++ b/src/mud.h
@@ -838,7 +838,7 @@ typedef enum
    CON_GET_OLD_PASSWORD, CON_CONFIRM_NEW_NAME,
    CON_GET_NEW_PASSWORD, CON_CONFIRM_NEW_PASSWORD,
    CON_GET_NEW_SEX, CON_GET_NEW_CLASS, CON_READ_MOTD,
-   CON_GET_NEW_RACE, CON_GET_EMULATION,
+   CON_GET_NEW_RACE, CON_GET_ENERGY_COLOR, CON_GET_EMULATION,
    CON_GET_WANT_RIPANSI, CON_TITLE, CON_PRESS_ENTER,
    CON_WAIT_1, CON_WAIT_2, CON_WAIT_3,
    CON_ACCEPTED, CON_GET_PKILL, CON_READ_IMOTD,
@@ -2606,6 +2606,7 @@ struct pc_data
    const char *prompt;  							/* User config prompts */
    const char *fprompt; 							/* Fight prompts */
    const char *subprompt;  						/* Substate prompt */
+   const char *energy_color;  				/* Preferred energy aura color */
    short pagerlen;   								/* For pager (NOT menus) */
    IGNORE_DATA *first_ignored;   				/* keep track of who to ignore */
    IGNORE_DATA *last_ignored;
@@ -4834,6 +4835,12 @@ void send_to_char_color( const char *txt, CHAR_DATA * ch );
 void send_to_desc_color( const char *txt, DESCRIPTOR_DATA * d );
 void send_to_pager( const char *txt, CHAR_DATA * ch );
 void send_to_pager_color( const char *txt, CHAR_DATA * ch );
+void set_char_color( short AType, CHAR_DATA * ch );
+void set_pager_color( short AType, CHAR_DATA * ch );
+void show_energy_color_choices( DESCRIPTOR_DATA *d );
+bool set_energy_color( CHAR_DATA *ch, const char *name );
+const char *get_energy_color_name( const CHAR_DATA *ch );
+const char *get_energy_color_token( const CHAR_DATA *ch );
 void ch_printf( CHAR_DATA * ch, const char *fmt, ... ) __attribute__ ( ( format( printf, 2, 3 ) ) );
 void ch_printf_color( CHAR_DATA * ch, const char *fmt, ... ) __attribute__ ( ( format( printf, 2, 3 ) ) );
 void pager_printf( CHAR_DATA * ch, const char *fmt, ... ) __attribute__ ( ( format( printf, 2, 3 ) ) );

--- a/src/player.c
+++ b/src/player.c
@@ -181,6 +181,18 @@ void do_score( CHAR_DATA* ch, const char* argument )
    pager_printf( ch, "&cRace : &w%-10.10s&c                           Played: &z%ld hours\r\n&D",
                  capitalize( get_race( ch ) ), ( long int )GET_TIME_PLAYED( ch ) );
 
+   {
+      char aura_name[32];
+      const char *token = get_energy_color_token( ch );
+
+      strlcpy( aura_name, get_energy_color_name( ch ), sizeof( aura_name ) );
+      if( aura_name[0] )
+         aura_name[0] = UPPER( aura_name[0] );
+
+      pager_printf( ch, "&cAura : %s%-10.10s&d&c                           Powerup Tier: &w%-2d&c\r\n&D",
+                    token, aura_name, ch->powerup );
+   }
+
    pager_printf( ch, "&cYEARS: &w%-6d&c                               Log In: &z%s\r&D",
                  calculate_age( ch ), ctime( &( ch->logon ) ) );
 

--- a/src/save.c
+++ b/src/save.c
@@ -492,6 +492,8 @@ void fwrite_char( CHAR_DATA * ch, FILE * fp )
       fprintf( fp, "Prompt       %s~\n", ch->pcdata->prompt );
    if( ch->pcdata->fprompt && *ch->pcdata->fprompt )
       fprintf( fp, "FPrompt	     %s~\n", ch->pcdata->fprompt );
+   if( ch->pcdata->energy_color && ch->pcdata->energy_color[0] != '\0' )
+      fprintf( fp, "EnergyColor  %s~\n", ch->pcdata->energy_color );
    if( ch->pcdata->pagerlen != 24 )
       fprintf( fp, "Pagerlen     %d\n", ch->pcdata->pagerlen );
 
@@ -859,6 +861,7 @@ bool load_char_obj( DESCRIPTOR_DATA * d, char *name, bool preload, bool copyover
    ch->desc = d;
    ch->pcdata->filename = STRALLOC( name );
    ch->name = NULL;
+   set_energy_color( ch, "white" );
    if( d->host )
       ch->pcdata->recent_site = STRALLOC( d->host );
    ch->act = multimeb( PLR_BLANK, PLR_COMBINE, PLR_PROMPT, -1 );
@@ -1927,6 +1930,14 @@ void fread_char( CHAR_DATA * ch, FILE * fp, bool preload, bool copyover )
                break;
 
          case 'E':
+            if( !strcmp( word, "EnergyColor" ) )
+            {
+               if( ch->pcdata->energy_color )
+                  STRFREE( ch->pcdata->energy_color );
+               ch->pcdata->energy_color = fread_string( fp );
+               fMatch = TRUE;
+               break;
+            }
             if( !strcmp( word, "End" ) )
             {
                if( !ch->short_descr )


### PR DESCRIPTION
## Summary
- add energy color selection to character creation and store the choice on player data
- expose aura selection on the score sheet and colorized act strings using the chosen energy color
- save and load energy colors and add matching aura messaging when casting energy blast

## Testing
- `make smaug CYGWIN=` *(fails: No rule to make target 'smaug')*

------
https://chatgpt.com/codex/tasks/task_e_68e009a0b9a88327884eeb0782b77242