### PR TITLE
Implement DBSC-style death penalty

### DIFF
--- a/src/fight.c
+++ b/src/fight.c
@@ -3724,6 +3724,19 @@ OBJ_DATA *raw_kill( CHAR_DATA * ch, CHAR_DATA * victim )
       return corpse_to_return;
    }
 
+   /* Apply death penalty for players */
+   if( !IS_NPC( victim ) )
+   {
+      long long current_pl = get_power_level( victim );
+      long long death_penalty = current_pl / 20;   /* 5% loss */
+
+      if( death_penalty < 100 && current_pl > 1000 )
+         death_penalty = 100;
+
+      if( death_penalty > 0 )
+         gain_pl( victim, -death_penalty, true );
+   }
+
    set_char_color( AT_DIEMSG, victim );
    if( victim->pcdata->mdeaths + victim->pcdata->pdeaths < 3 )
       do_help( victim, "new_death" );

--- a/src/mud_comm.c
+++ b/src/mud_comm.c
@@ -3311,17 +3311,8 @@ ch_ret simple_damage( CHAR_DATA * ch, CHAR_DATA * victim, int dam, int dt )
          log_string( log_buf );
          to_channel( log_buf, CHANNEL_DEATH, "Death", LEVEL_IMMORTAL );
 
-         /*
-          * Death penalty: Lose 10% of current power level
-          */
-         long long current_pl = get_power_level( victim );
-         if( current_pl > 100 )  /* Don't penalize very weak characters */
-         {
-            long long death_penalty = current_pl / 10;  /* Lose 10% of current PL */
-            gain_pl( victim, -death_penalty, true );    /* Show the loss message */
-         }
       }
-      
+
       set_cur_char( victim );
       raw_kill( ch, victim );
       victim = NULL;


### PR DESCRIPTION
## Summary
- add the DBSC-style player death penalty to `raw_kill` so it always triggers during player death handling
- remove the previous 10% death penalty applied in `simple_damage` to avoid double penalties

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e06bf9003c8327b3e4bb5005f339b4