### PR TITLE
Adjust experience multipliers for races

### DIFF
--- a/races/Android.race
+++ b/races/Android.race
@@ -18,7 +18,7 @@ Align       0
 Min_Align  -1000
 Max_Align	1000
 AC_Plus    0
-Exp_Mult   100
+Exp_Mult   120
 Attacks    0
 Defenses   0
 Height     70

--- a/races/Arcosian.race
+++ b/races/Arcosian.race
@@ -18,7 +18,7 @@ Align       -200
 Min_Align  -1000
 Max_Align	0
 AC_Plus    -2
-Exp_Mult   125
+Exp_Mult   150
 Attacks    0
 Defenses   0
 Height     60

--- a/races/Bio-Android.race
+++ b/races/Bio-Android.race
@@ -18,7 +18,7 @@ Align       -200
 Min_Align  -1000
 Max_Align	1000
 AC_Plus    -1
-Exp_Mult   85
+Exp_Mult    80
 Attacks    0
 Defenses   0
 Height     75

--- a/races/Lycan.race
+++ b/races/Lycan.race
@@ -18,7 +18,7 @@ Align       -50
 Min_Align  -500
 Max_Align	500
 AC_Plus    -1
-Exp_Mult   95
+Exp_Mult    80
 Attacks    0
 Defenses   0
 Height     74

--- a/races/Vampire.race
+++ b/races/Vampire.race
@@ -18,7 +18,7 @@ Align       -100
 Min_Align  -1000
 Max_Align	500
 AC_Plus    -1
-Exp_Mult   90
+Exp_Mult    80
 Attacks    0
 Defenses   0
 Height     72


### PR DESCRIPTION
## Summary
- update Android race to use the fast learner experience multiplier
- lower Bio-Android, Lycan, and Vampire races to the slow learner experience multiplier
- increase the Arcosian race to use the very fast learner multiplier

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e06eab8bd48327b0b8e0e731d424e5