### PR TITLE
Restrict ambient aura updates to resting players

### DIFF
--- a/src/update.c
+++ b/src/update.c
@@ -1004,7 +1004,8 @@ void char_update( void )
       if( ch->position == POS_STUNNED )
          update_pos( ch );
 
-      if( !IS_NPC( ch ) )
+      /* Show ambient aura messages for players with powerups/transformations */
+      if( !IS_NPC( ch ) && ch->position >= POS_RESTING )
          ambient_aura_update( ch );
 
       /*


### PR DESCRIPTION
## Summary
- ensure ambient aura updates only run for player characters that are at least resting in char_update

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e078c3b938832791b154a1ddde51c7