### PR TITLE
Remove redundant color declarations and clean unused variable

### DIFF
--- a/src/mud.h
+++ b/src/mud.h
@@ -4835,8 +4835,6 @@ void send_to_char_color( const char *txt, CHAR_DATA * ch );
 void send_to_desc_color( const char *txt, DESCRIPTOR_DATA * d );
 void send_to_pager( const char *txt, CHAR_DATA * ch );
 void send_to_pager_color( const char *txt, CHAR_DATA * ch );
-void set_char_color( short AType, CHAR_DATA * ch );
-void set_pager_color( short AType, CHAR_DATA * ch );
 void show_energy_color_choices( DESCRIPTOR_DATA *d );
 bool set_energy_color( CHAR_DATA *ch, const char *name );
 const char *get_energy_color_name( const CHAR_DATA *ch );

--- a/src/update.c
+++ b/src/update.c
@@ -803,8 +803,6 @@ void char_calendar_update( void )
  ****************************************************************************/
 void ambient_aura_update( CHAR_DATA *ch )
 {
-   static int aura_pulse = 0;
-
    if( IS_NPC( ch ) )
       return;
 


### PR DESCRIPTION
## Summary
- remove duplicate color function declarations from mud.h that are already provided by color.h
- drop the unused aura_pulse tracker in ambient_aura_update to silence the compiler warning

## Testing
- make (fails: build spammed with existing redundant declaration warnings; interrupted)


------
https://chatgpt.com/codex/tasks/task_e_68e08000d24c83279dff7339af7762a9