### PR TITLE
Add visible aura feedback for powered-up characters

### DIFF
--- a/src/act_info.c
+++ b/src/act_info.c
@@ -892,6 +892,7 @@ void show_char_to_char_0( CHAR_DATA * victim, CHAR_DATA * ch )
       else
          strlcat( buf, victim->long_descr, MAX_STRING_LENGTH );
       send_to_char( buf, ch );
+      show_powerup_aura_to_char( victim, ch );
       show_visible_affects_to_char( victim, ch );
       return;
    }
@@ -1031,6 +1032,7 @@ void show_char_to_char_0( CHAR_DATA * victim, CHAR_DATA * ch )
    strlcat( buf, "\r\n", MAX_STRING_LENGTH );
    buf[0] = UPPER( buf[0] );
    send_to_char( buf, ch );
+   show_powerup_aura_to_char( victim, ch );
    show_visible_affects_to_char( victim, ch );
 }
 
@@ -1070,6 +1072,8 @@ void show_char_to_char_1( CHAR_DATA * victim, CHAR_DATA * ch )
 
    show_race_line( ch, victim );
    show_condition( ch, victim );
+
+   show_powerup_aura_to_char( victim, ch );
 
    found = FALSE;
    for( iWear = 0; iWear < MAX_WEAR; iWear++ )

--- a/src/mud.h
+++ b/src/mud.h
@@ -4203,6 +4203,8 @@ DECLARE_DO_FUN( do_poison_weapon );
 DECLARE_DO_FUN( do_pose );
 DECLARE_DO_FUN( do_pounce );
 DECLARE_DO_FUN( do_powerup );
+
+void show_powerup_aura_to_char( CHAR_DATA *victim, CHAR_DATA *ch );
 DECLARE_DO_FUN( do_powerdown );
 DECLARE_DO_FUN( do_practice );
 DECLARE_DO_FUN( do_project );

--- a/src/powerup.c
+++ b/src/powerup.c
@@ -160,7 +160,7 @@ void apply_powerup_to_splits( CHAR_DATA *ch, short powerup_tier )
     /* This function should iterate through any split forms and apply
      * the same power up level to them. Implementation depends on how
      * your split system works. Example framework:
-     * 
+     *
      * CHAR_DATA *split;
      * for( split = first_split_of(ch); split; split = next_split_of(ch) )
      * {
@@ -170,13 +170,67 @@ void apply_powerup_to_splits( CHAR_DATA *ch, short powerup_tier )
      */
 }
 
+typedef struct powerup_aura_desc POWERUP_AURA_DESC;
+
+struct powerup_aura_desc
+{
+    const char *self;
+    const char *other;
+};
+
+static const POWERUP_AURA_DESC powerup_aura_table[] =
+{
+    { NULL, NULL },
+    { "A faint aura flickers around you.",
+      "%s is wrapped in a faint, shimmering aura." },
+    { "Your aura hums and tightens against your skin.",
+      "%s's aura hums and tightens in the air." },
+    { "Power crackles around you, stirring dust at your feet.",
+      "Power crackles around %s, stirring dust across the ground." },
+    { "A pressure wave ripples from you as your aura flares.",
+      "A pressure wave ripples from %s as the surrounding aura flares." },
+    { "Blazing arcs of energy roar outward from your aura.",
+      "Blazing arcs of energy roar outward from %s's aura." },
+    { "A tight halo of power snaps into place and kicks up a dust ring.",
+      "A tight halo of power snaps around %s, kicking a ring of dust outward." },
+    { "Light burns at your edges as shockwaves tear through the air.",
+      "Light burns at %s's edges while shockwaves tear through the air." }
+};
+
+void show_powerup_aura_to_char( CHAR_DATA *victim, CHAR_DATA *ch )
+{
+    char aura_buf[MAX_STRING_LENGTH];
+    short tier, max_tier_index;
+    const POWERUP_AURA_DESC *desc;
+
+    if( !victim || !ch )
+        return;
+
+    if( victim->powerup <= 0 )
+        return;
+
+    max_tier_index = (short)( sizeof( powerup_aura_table ) / sizeof( powerup_aura_table[0] ) ) - 1;
+    tier = URANGE( 1, victim->powerup, max_tier_index );
+    desc = &powerup_aura_table[tier];
+
+    if( !desc->self || !desc->other )
+        return;
+
+    if( ch == victim )
+        strlcpy( aura_buf, desc->self, sizeof( aura_buf ) );
+    else
+        snprintf( aura_buf, sizeof( aura_buf ), desc->other, PERS( victim, ch ) );
+
+    ch_printf_color( ch, "%s%s&D\r\n", get_energy_color_token( victim ), aura_buf );
+}
+
 /* Remove transformation stat bonuses (placeholder) */
 void transStatRemove( CHAR_DATA *ch )
 {
     /* This function should remove any stat bonuses applied by transformations
      * Implementation depends on your transformation system
      * Basic example: */
-    
+
     /* affect_strip(ch, gsn_powerup); - Remove powerup affects if you use affects */
     /* Remove any other transformation bonuses here */
 }


### PR DESCRIPTION
## Summary
- add reusable helper that builds colored aura descriptions for each powerup tier
- show powerup aura text when characters appear in room lists or when looked at directly
- expose the helper declaration for other modules

## Testing
- make *(fails: linker flag `--export-all-symbols` is not supported in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e0995b357483278962ca6266a3b7ee