### PR TITLE
Clear Dragus vassign range

### DIFF
--- a/player/d/Dragus
+++ b/player/d/Dragus
@@ -45,9 +45,9 @@ Password     8c6976e5b5410415bde908bd4dee15dfb167a9c873fc4bb8a81f6f2ab448a918~
 Title         the Attendant~
 Restore_time 1756773552
 WizInvis     65
-RoomRange    55000 59999
-ObjRange     55000 59999
-MobRange     55000 59999
+RoomRange    0 0
+ObjRange     0 0
+MobRange     0 0
 Flags        16809984
 PKills       0
 PDeaths      0


### PR DESCRIPTION
## Summary
- reset Dragus' room, object, and mob vnum ranges to 0 so the character is no longer marked as having a vassign

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0b2a017e88327829e049072508b4f