### PR TITLE
Avoid duplicate power down messaging

### DIFF
--- a/src/powerup.c
+++ b/src/powerup.c
@@ -354,9 +354,7 @@ void do_powerdown( CHAR_DATA *ch, const char *argument )
         
         /* Set new power tier */
         ch->powerup = new_tier;
-        
-        ch_printf( ch, "Power level reduced.\r\n" );
-        
+
         /* Apply to split forms if you have that system */
         /* apply_powerup_to_splits(ch, new_tier); */
     }


### PR DESCRIPTION
## Summary
- remove the generic "Power level reduced." notification so only the immersive power-down messaging remains

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0b9364a6c83278c38f473b9e6d338