### PR TITLE
Simplify max powerup messaging

### DIFF
--- a/src/powerup.c
+++ b/src/powerup.c
@@ -292,8 +292,7 @@ void do_powerup( CHAR_DATA *ch, const char *argument )
     
     if( using_max_command && target_tier == max_tier )
     {
-        act( AT_WHITE, "&WYou unleash every ounce of power, catapulting straight to your ultimate form!&D", ch, NULL, NULL, TO_CHAR );
-        act( AT_WHITE, "&W$n erupts in a blinding surge, rocketing straight to $s maximum power!&D", ch, NULL, NULL, TO_ROOM );
+        act( AT_WHITE, "&W$n channels a blinding surge as $e pushes straight to maximum power!&D", ch, NULL, NULL, TO_ROOM );
     }
 
     apply_powerup_effects(ch, target_tier);


### PR DESCRIPTION
## Summary
- remove the redundant player-facing message triggered by `powerup max`
- reword the room broadcast to simply describe surging to maximum power

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e18669005083278a745edc533a5c4e