### PR TITLE
Fix brace handling in act_string

### DIFF
--- a/src/comm.c
+++ b/src/comm.c
@@ -3117,6 +3117,8 @@ char *act_string( const char *format, CHAR_DATA * to, CHAR_DATA * ch, const void
 
       if( *str == '{' )
       {
+         bool recognized = true;
+
          ++str;
          if( *str == '\0' )
             break;
@@ -3148,10 +3150,13 @@ char *act_string( const char *format, CHAR_DATA * to, CHAR_DATA * ch, const void
             default:
                *point++ = '{';
                *point++ = *str;
+               recognized = false;
                break;
          }
 
          ++str;
+         if( recognized && *str == '}' )
+            ++str;
          continue;
       }
 


### PR DESCRIPTION
## Summary
- skip optional closing braces after recognized `{}` color tokens in `act_string`
- keep unknown brace sequences unchanged to preserve existing behavior

## Testing
- `g++ -c src/comm.c -Isrc -o /tmp/comm.o`
- `/tmp/test_act_string`
- `make -f Makefile.devcc` *(fails: gcc.exe not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e1961d5d08832796095f142d1a552b