### PR TITLE
Increase Highgard area max vnums to 999

### DIFF
--- a/area/highgard.are
+++ b/area/highgard.are
@@ -309,7 +309,7 @@ Saves      0 0 0 0 0
 #ENDMOBILE
 
 #MOBILE
-Vnum       299
+Vnum       999
 Keywords   placeholder mob~
 Short      a placeholder mob~
 Long       A placeholder mob is here, holding the place.
@@ -377,7 +377,7 @@ Stats    0 0 0 0 0
 #ENDOBJECT
 
 #OBJECT
-Vnum     299
+Vnum     999
 Keywords placeholder obj~
 Type     weapon~
 Short    a placeholder obj~
@@ -1297,7 +1297,7 @@ Flags    nomob prototype~
 #ENDROOM
 
 #ROOM
-Vnum     299
+Vnum     999
 Name     Placeholder Space~
 Sector   inside~
 Flags    nomob indoors~


### PR DESCRIPTION
## Summary
- update the Highgard placeholder mobile, object, and room entries to use vnum 999 so the area supports higher allocations

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e198fcdca88327bd52e51357b3cb75