### PR TITLE
Allow mob programs to set player aura colors

### DIFF
--- a/area/help.are
+++ b/area/help.are
@@ -7847,6 +7847,7 @@ mpbodybag          mpbodybag 0.$n          Not currently in use.
 mpfillin           mpfillin <dir>          Closes off exits
 mplog              mplog <text>            Logs mob activity
 mposet/mpmset      mp$set <field> <value>  Osets and Msets objs mobs.
+                    Use aura/energycolor to attune a player's aura color.
 mpnuisance         mpnuisance $n <val>...  Sets player to nuisance (in use?)
 mpscatter          mpscatter $n vnum vnum  Do not use.
 mpstrew            unknown                 unknown

--- a/src/mpxset.c
+++ b/src/mpxset.c
@@ -84,6 +84,23 @@ void do_mpmset( CHAR_DATA* ch, const char* argument )
    if( atoi( arg3 ) < -1 && value == -1 )
       value = atoi( arg3 );
 
+   if( !str_cmp( arg2, "aura" ) || !str_cmp( arg2, "energycolor" ) )
+   {
+      if( IS_NPC( victim ) )
+      {
+         progbug( "MpMset: aura on NPC", ch );
+         return;
+      }
+
+      if( !set_energy_color( victim, arg3 ) )
+      {
+         progbug( "MpMset: invalid aura color", ch );
+         return;
+      }
+
+      return;
+   }
+
    if( !str_cmp( arg2, "str" ) )
    {
       if( value < minattr || value > maxattr )


### PR DESCRIPTION
## Summary
- allow mob programs to set player aura colors using the shared validation helper
- ensure invalid or NPC targets are rejected with informative progbug messages
- document the aura/energycolor mpmset field for builders

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e468c1cca0832781607ee140cddbfc